### PR TITLE
feat: Claude Battery macOS menu bar widget

### DIFF
--- a/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
+++ b/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
@@ -47,7 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Observe auth state changes to start/stop polling
         authManager.$isAuthenticated
-            .dropFirst() // Skip the initial value (already handled above)
+            .dropFirst()
             .receive(on: RunLoop.main)
             .sink { [weak self] isAuthenticated in
                 guard let self else { return }
@@ -60,16 +60,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .store(in: &cancellables)
     }
 
-    nonisolated func applicationWillTerminate(_ notification: Notification) {
-        Task { @MainActor in
-            usageService?.stopPolling()
-        }
-    }
-
     func signOut() {
         usageService.stopPolling()
-        Task {
-            await authManager.signOut()
-        }
+        authManager.signOut()
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
@@ -136,6 +136,7 @@ class MenuBarController {
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(
             rootView: UsagePopoverView(
+                authManager: authManager,
                 usageService: usageService,
                 onSignIn: { [weak self] in self?.authManager.presentLogin() }
             )
@@ -176,7 +177,9 @@ class MenuBarController {
         guard let button = statusItem.button else { return }
         NSApp.activate(ignoringOtherApps: true)
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        popover.contentViewController?.view.window?.makeKey()
+        DispatchQueue.main.async { [weak self] in
+            self?.popover.contentViewController?.view.window?.makeKey()
+        }
     }
 
     private func showContextMenu() {

--- a/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
@@ -13,6 +13,101 @@ class MenuBarController {
     private let digitFont = NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .medium)
     private let smallFont = NSFont.monospacedDigitSystemFont(ofSize: 7, weight: .regular)
 
+    // Cached static icons
+    private lazy var unauthenticatedIcon: NSImage = {
+        let iconSize = NSSize(width: 34, height: 18)
+        let image = NSImage(size: iconSize, flipped: false) { rect in
+            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
+            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
+            NSColor.black.setStroke()
+            path.lineWidth = 1.0
+            path.stroke()
+
+            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }()
+
+    private lazy var loadingIcon: NSImage = {
+        let iconSize = NSSize(width: 40, height: 18)
+        let font = digitFont
+        let image = NSImage(size: iconSize, flipped: false) { rect in
+            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
+            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
+            NSColor.black.setStroke()
+            path.lineWidth = 1.0
+            path.stroke()
+
+            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
+
+            let text = "..." as NSString
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
+            let size = text.size(withAttributes: attrs)
+            text.draw(at: NSPoint(x: 7, y: (18 - size.height) / 2), withAttributes: attrs)
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }()
+
+    private lazy var staleIcon: NSImage = {
+        let iconSize = NSSize(width: 40, height: 18)
+        let font = digitFont
+        let image = NSImage(size: iconSize, flipped: false) { rect in
+            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
+            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
+            NSColor.gray.setStroke()
+            path.lineWidth = 1.0
+            path.stroke()
+
+            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
+            NSColor.gray.setFill()
+            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
+
+            let text = "..." as NSString
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.gray]
+            let size = text.size(withAttributes: attrs)
+            text.draw(at: NSPoint(x: 7, y: (18 - size.height) / 2), withAttributes: attrs)
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }()
+
+    private lazy var errorIcon: NSImage = {
+        let iconSize = NSSize(width: 40, height: 18)
+        let font = digitFont
+        let image = NSImage(size: iconSize, flipped: false) { rect in
+            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
+            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
+            NSColor.gray.setStroke()
+            path.lineWidth = 1.0
+            path.stroke()
+
+            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
+            NSColor.gray.setFill()
+            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
+
+            let text = "!" as NSString
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.gray]
+            let size = text.size(withAttributes: attrs)
+            text.draw(at: NSPoint(x: 12, y: (18 - size.height) / 2), withAttributes: attrs)
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }()
+
     init(authManager: AuthManager, usageService: UsageService) {
         self.authManager = authManager
         self.usageService = usageService
@@ -49,13 +144,9 @@ class MenuBarController {
 
     private func setupObservers() {
         usageService.$latestUsage
-            .combineLatest(
-                usageService.$consecutiveFailures,
-                usageService.$lastSuccessfulFetch,
-                authManager.$isAuthenticated
-            )
+            .combineLatest(usageService.$consecutiveFailures, authManager.$isAuthenticated)
             .receive(on: RunLoop.main)
-            .sink { [weak self] usage, failures, lastFetch, isAuth in
+            .sink { [weak self] usage, _, isAuth in
                 self?.updateIcon(usage, isAuthenticated: isAuth)
             }
             .store(in: &cancellables)
@@ -94,7 +185,6 @@ class MenuBarController {
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
 
-        // Set targets for menu items
         for item in menu.items where item.action != nil {
             item.target = self
         }
@@ -123,15 +213,15 @@ class MenuBarController {
         let image: NSImage
 
         if !isAuthenticated {
-            image = makeUnauthenticatedIcon()
+            image = unauthenticatedIcon
         } else if let usage = usage {
             image = makeBatteryIcon(usage: usage)
         } else if usageService.consecutiveFailures >= 10 {
-            image = makeErrorIcon()
+            image = errorIcon
         } else if usageService.isStale && usageService.consecutiveFailures >= 3 {
-            image = makeStaleIcon()
+            image = staleIcon
         } else {
-            image = makeLoadingIcon()
+            image = loadingIcon
         }
 
         statusItem.button?.image = image
@@ -145,22 +235,37 @@ class MenuBarController {
         let weeklyResetText = formatResetTime(usage.weeklyResetDate)
         let sessionResetText = formatResetTime(usage.sessionResetDate)
 
-        let totalWidth: CGFloat = computeIconWidth(weeklyPercent: weeklyPercent, weeklyReset: weeklyResetText, sessionPercent: sessionPercent, sessionReset: sessionResetText)
+        // Compute text sizes once
+        let percentFontAttrs: [NSAttributedString.Key: Any] = [.font: digitFont]
+        let resetFontAttrs: [NSAttributedString.Key: Any] = [.font: smallFont]
+
+        let weeklyPercentStr = "\(weeklyPercent)%" as NSString
+        let weeklyResetStr = weeklyResetText as NSString
+        let sessionPercentStr = "\(sessionPercent)%" as NSString
+        let sessionResetStr = sessionResetText as NSString
+
+        let weeklyPercentSize = weeklyPercentStr.size(withAttributes: percentFontAttrs)
+        let weeklyResetSize = weeklyResetStr.size(withAttributes: resetFontAttrs)
+        let sessionPercentSize = sessionPercentStr.size(withAttributes: percentFontAttrs)
+        let sessionResetSize = sessionResetStr.size(withAttributes: resetFontAttrs)
+
+        let batteryWidth: CGFloat = 30
+        let batteryHeight: CGFloat = 12
+        let nubWidth: CGFloat = 2
+        let nubHeight: CGFloat = 5
+        let sessionBarWidth: CGFloat = 3
+        let sessionBarHeight: CGFloat = 10
+        let cornerRadius: CGFloat = 2
+        let fillInset: CGFloat = 1.5
         let iconHeight: CGFloat = 18
 
+        let totalWidth = batteryWidth + nubWidth + 2 + weeklyPercentSize.width + 2 + weeklyResetSize.width + 4 + 0.5 + 4 + sessionBarWidth + 2 + sessionPercentSize.width + 2 + sessionResetSize.width + 1
+
         let fgColor: NSColor = isLowBattery ? .white : .black
-        let font = digitFont
-        let sFont = smallFont
         let batteryColor: NSColor = isLowBattery ? .systemRed : .black
 
         let image = NSImage(size: NSSize(width: totalWidth, height: iconHeight), flipped: false) { rect in
-            let batteryWidth: CGFloat = 30
-            let batteryHeight: CGFloat = 12
             let batteryY: CGFloat = (iconHeight - batteryHeight) / 2
-            let nubWidth: CGFloat = 2
-            let nubHeight: CGFloat = 5
-            let cornerRadius: CGFloat = 2
-            let fillInset: CGFloat = 1.5
 
             // Battery outline
             let bodyRect = NSRect(x: 0, y: batteryY, width: batteryWidth, height: batteryHeight)
@@ -191,26 +296,22 @@ class MenuBarController {
                 )
                 let fillColor: NSColor = isLowBattery ? .systemRed : batteryColor
                 fillColor.setFill()
-                let fillPath = NSBezierPath(roundedRect: fillRect, xRadius: 1, yRadius: 1)
-                fillPath.fill()
+                NSBezierPath(roundedRect: fillRect, xRadius: 1, yRadius: 1).fill()
             }
 
             // Weekly % text
-            let percentText = "\(weeklyPercent)%" as NSString
-            let percentAttrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: fgColor]
-            let percentSize = percentText.size(withAttributes: percentAttrs)
+            let percentDrawAttrs: [NSAttributedString.Key: Any] = [.font: self.digitFont, .foregroundColor: fgColor]
+            let resetDrawAttrs: [NSAttributedString.Key: Any] = [.font: self.smallFont, .foregroundColor: fgColor]
+
             let percentX = batteryWidth + nubWidth + 2
-            percentText.draw(at: NSPoint(x: percentX, y: (iconHeight - percentSize.height) / 2), withAttributes: percentAttrs)
+            weeklyPercentStr.draw(at: NSPoint(x: percentX, y: (iconHeight - weeklyPercentSize.height) / 2), withAttributes: percentDrawAttrs)
 
             // Weekly reset text
-            let resetAttrs: [NSAttributedString.Key: Any] = [.font: sFont, .foregroundColor: fgColor]
-            let resetText = weeklyResetText as NSString
-            let resetSize = resetText.size(withAttributes: resetAttrs)
-            let resetX = percentX + percentSize.width + 2
-            resetText.draw(at: NSPoint(x: resetX, y: (iconHeight - resetSize.height) / 2), withAttributes: resetAttrs)
+            let resetX = percentX + weeklyPercentSize.width + 2
+            weeklyResetStr.draw(at: NSPoint(x: resetX, y: (iconHeight - weeklyResetSize.height) / 2), withAttributes: resetDrawAttrs)
 
             // Divider
-            let dividerX = resetX + resetSize.width + 4
+            let dividerX = resetX + weeklyResetSize.width + 4
             let dividerColor: NSColor = isLowBattery ? .white.withAlphaComponent(0.5) : .black.withAlphaComponent(0.3)
             dividerColor.setStroke()
             let dividerPath = NSBezierPath()
@@ -221,8 +322,6 @@ class MenuBarController {
 
             // Session bar
             let sessionBarX = dividerX + 4
-            let sessionBarWidth: CGFloat = 3
-            let sessionBarHeight: CGFloat = 10
             let sessionBarY = (iconHeight - sessionBarHeight) / 2
             let sessionFillHeight = sessionBarHeight * CGFloat(sessionPercent) / 100.0
 
@@ -240,99 +339,17 @@ class MenuBarController {
             }
 
             // Session % text
-            let sessionText = "\(sessionPercent)%" as NSString
-            let sessionSize = sessionText.size(withAttributes: percentAttrs)
             let sessionTextX = sessionBarX + sessionBarWidth + 2
-            sessionText.draw(at: NSPoint(x: sessionTextX, y: (iconHeight - sessionSize.height) / 2), withAttributes: percentAttrs)
+            sessionPercentStr.draw(at: NSPoint(x: sessionTextX, y: (iconHeight - sessionPercentSize.height) / 2), withAttributes: percentDrawAttrs)
 
             // Session reset text
-            let sessionResetStr = sessionResetText as NSString
-            let sessionResetSize = sessionResetStr.size(withAttributes: resetAttrs)
-            let sessionResetX = sessionTextX + sessionSize.width + 2
-            sessionResetStr.draw(at: NSPoint(x: sessionResetX, y: (iconHeight - sessionResetSize.height) / 2), withAttributes: resetAttrs)
+            let sessionResetX = sessionTextX + sessionPercentSize.width + 2
+            sessionResetStr.draw(at: NSPoint(x: sessionResetX, y: (iconHeight - sessionResetSize.height) / 2), withAttributes: resetDrawAttrs)
 
             return true
         }
 
         image.isTemplate = !isLowBattery
-        return image
-    }
-
-    private func makeUnauthenticatedIcon() -> NSImage {
-        let iconSize = NSSize(width: 34, height: 18)
-        let image = NSImage(size: iconSize, flipped: false) { rect in
-            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
-            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
-            NSColor.black.setStroke()
-            path.lineWidth = 1.0
-            path.stroke()
-
-            // Nub
-            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
-            NSColor.black.setFill()
-            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
-
-            return true
-        }
-        image.isTemplate = true
-        return image
-    }
-
-    private func makeLoadingIcon() -> NSImage {
-        let iconSize = NSSize(width: 40, height: 18)
-        let font = digitFont
-        let image = NSImage(size: iconSize, flipped: false) { rect in
-            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
-            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
-            NSColor.black.setStroke()
-            path.lineWidth = 1.0
-            path.stroke()
-
-            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
-            NSColor.black.setFill()
-            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
-
-            let text = "..." as NSString
-            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
-            let size = text.size(withAttributes: attrs)
-            text.draw(at: NSPoint(x: 7, y: (18 - size.height) / 2), withAttributes: attrs)
-
-            return true
-        }
-        image.isTemplate = true
-        return image
-    }
-
-    private func makeStaleIcon() -> NSImage {
-        let icon = makeLoadingIcon()
-        icon.lockFocus()
-        NSColor.black.withAlphaComponent(0.5).setFill()
-        icon.unlockFocus()
-        return icon
-    }
-
-    private func makeErrorIcon() -> NSImage {
-        let iconSize = NSSize(width: 40, height: 18)
-        let font = digitFont
-        let image = NSImage(size: iconSize, flipped: false) { rect in
-            let batteryRect = NSRect(x: 0, y: 3, width: 30, height: 12)
-            let path = NSBezierPath(roundedRect: batteryRect, xRadius: 2, yRadius: 2)
-            NSColor.gray.setStroke()
-            path.lineWidth = 1.0
-            path.stroke()
-
-            let nubRect = NSRect(x: 30, y: 5.5, width: 2, height: 5)
-            NSColor.gray.setFill()
-            NSBezierPath(roundedRect: nubRect, xRadius: 0.5, yRadius: 0.5).fill()
-
-            let text = "!" as NSString
-            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.gray]
-            let size = text.size(withAttributes: attrs)
-            text.draw(at: NSPoint(x: 12, y: (18 - size.height) / 2), withAttributes: attrs)
-
-            return true
-        }
-        image.isTemplate = true
         return image
     }
 
@@ -354,18 +371,5 @@ class MenuBarController {
         } else {
             return "\(max(1, minutes))m"
         }
-    }
-
-    private func computeIconWidth(weeklyPercent: Int, weeklyReset: String, sessionPercent: Int, sessionReset: String) -> CGFloat {
-        let percentAttrs: [NSAttributedString.Key: Any] = [.font: digitFont]
-        let resetAttrs: [NSAttributedString.Key: Any] = [.font: smallFont]
-
-        let weeklyPercentWidth = ("\(weeklyPercent)%" as NSString).size(withAttributes: percentAttrs).width
-        let weeklyResetWidth = (weeklyReset as NSString).size(withAttributes: resetAttrs).width
-        let sessionPercentWidth = ("\(sessionPercent)%" as NSString).size(withAttributes: percentAttrs).width
-        let sessionResetWidth = (sessionReset as NSString).size(withAttributes: resetAttrs).width
-
-        // battery(30) + nub(2) + gap(2) + weeklyPercent + gap(2) + weeklyReset + gap(4) + divider(0.5) + gap(4) + sessionBar(3) + gap(2) + sessionPercent + gap(2) + sessionReset
-        return 30 + 2 + 2 + weeklyPercentWidth + 2 + weeklyResetWidth + 4 + 0.5 + 4 + 3 + 2 + sessionPercentWidth + 2 + sessionResetWidth + 1
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -1,19 +1,20 @@
 import SwiftUI
 
 struct UsagePopoverView: View {
+    @ObservedObject var authManager: AuthManager
     @ObservedObject var usageService: UsageService
     let onSignIn: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if let usage = usageService.latestUsage {
+            if !authManager.isAuthenticated {
+                unauthenticatedContent
+            } else if let usage = usageService.latestUsage {
                 authenticatedContent(usage: usage)
             } else if usageService.consecutiveFailures >= 10 {
                 errorContent
-            } else if usageService.lastSuccessfulFetch == nil && usageService.consecutiveFailures == 0 {
-                loadingContent
             } else {
-                unauthenticatedContent
+                loadingContent
             }
         }
         .padding(16)

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -180,10 +180,14 @@ struct UsagePopoverView: View {
         return "Updated \(minutes) min ago"
     }
 
-    private func formatResetDate(_ date: Date) -> String {
+    private static let resetDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM d 'at' h:mm a"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private func formatResetDate(_ date: Date) -> String {
+        Self.resetDateFormatter.string(from: date)
     }
 
     private func formatResetCountdown(_ date: Date) -> String {

--- a/todos/009-complete-p1-begin-activity-prevents-system-sleep.md
+++ b/todos/009-complete-p1-begin-activity-prevents-system-sleep.md
@@ -1,0 +1,71 @@
+---
+status: complete
+priority: p1
+issue_id: "009"
+tags: [code-review, performance, energy, macos]
+dependencies: []
+---
+
+# beginActivity(options: []) Prevents System Idle Sleep
+
+## Problem Statement
+
+`ProcessInfo.beginActivity(options: [])` in `UsageService.swift` passes an empty option set, which in Apple's API means **all flags are set** — including `.idleSystemSleepDisabled`. This prevents the entire Mac from sleeping while the app is running, draining battery unnecessarily.
+
+Found by: Performance Oracle (CRITICAL-1), Code Simplicity Reviewer
+
+## Findings
+
+- **Location:** `UsageService.swift` — `startPolling()` method
+- **Evidence:** Empty `OptionSet` in Swift initializes with all bits set. Apple docs confirm `ProcessInfo.ActivityOptions` follows this pattern.
+- **Impact:** Users' Macs will never idle-sleep while ClaudeBattery is running, causing significant battery drain on laptops.
+- **Simplicity note:** The Code Simplicity Reviewer additionally flagged that App Nap prevention may be unnecessary entirely — a 2-minute polling interval is coarse enough that App Nap delays won't meaningfully affect the user experience.
+
+## Proposed Solutions
+
+### Solution A: Use correct options (Recommended)
+- Use `.idleDisplaySleepDisabled` only if needed, or more likely just `.userInitiated` reason string
+- **Pros:** Fixes the bug, minimal change
+- **Cons:** Still prevents some power saving
+- **Effort:** Small
+- **Risk:** Low
+
+### Solution B: Remove beginActivity entirely
+- Remove App Nap prevention. Let macOS manage the app normally.
+- Timer fires will still work (just slightly delayed by App Nap).
+- **Pros:** Simplest, most energy-efficient, no side effects
+- **Cons:** Poll may be delayed by seconds when app is in background
+- **Effort:** Small
+- **Risk:** Low — polling delay is acceptable for a status display
+
+### Solution C: Use .latencyCritical only
+- `ProcessInfo.beginActivity(options: [.latencyCritical], reason: "Polling usage API")`
+- **Pros:** Prevents App Nap without preventing system sleep
+- **Cons:** Slightly more energy than Solution B
+- **Effort:** Small
+- **Risk:** Low
+
+## Recommended Action
+
+Solution B — remove `beginActivity` entirely. A menu bar usage display does not need sub-second timer accuracy.
+
+## Technical Details
+
+- **Affected files:** `ClaudeBattery/ClaudeBattery/Services/UsageService.swift`
+- **Components:** Energy management, polling timer
+
+## Acceptance Criteria
+
+- [ ] `ProcessInfo.beginActivity` with empty options is removed
+- [ ] Mac can idle-sleep normally with ClaudeBattery running
+- [ ] Polling still works (possibly with slight App Nap delay)
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |
+
+## Resources
+
+- [Apple ProcessInfo.ActivityOptions docs](https://developer.apple.com/documentation/foundation/processinfo/activityoptions)

--- a/todos/010-complete-p1-make-stale-icon-noop-bug.md
+++ b/todos/010-complete-p1-make-stale-icon-noop-bug.md
@@ -1,0 +1,59 @@
+---
+status: complete
+priority: p1
+issue_id: "010"
+tags: [code-review, bug, ui, drawing]
+dependencies: []
+---
+
+# makeStaleIcon() Drawing Bug — No-Op Fill
+
+## Problem Statement
+
+`makeStaleIcon()` in `MenuBarController.swift` calls `lockFocus()`, `setFill()`, then `unlockFocus()` without actually drawing a fill path. The stale icon is visually identical to the loading icon, meaning users get no visual feedback when data is stale.
+
+Found by: Pattern Recognition Specialist (HIGH), Performance Oracle (OPT-3), Code Simplicity Reviewer
+
+## Findings
+
+- **Location:** `MenuBarController.swift:306-312`
+- **Evidence:** `icon.lockFocus(); NSColor.black.withAlphaComponent(0.5).setFill(); icon.unlockFocus()` — `setFill()` only sets the current fill color but doesn't draw anything. A `NSBezierPath.fill()` or `NSRectFill()` call is needed.
+- **Additional:** `lockFocus/unlockFocus` is deprecated in macOS 12+ in favor of `NSImage(size:flipped:drawingHandler:)`.
+- **Impact:** Stale state is invisible to users. They see the same "..." loading icon whether the app is loading or has stale data.
+
+## Proposed Solutions
+
+### Solution A: Remove makeStaleIcon, use loading icon with alpha (Recommended)
+- Apply alpha to the loading icon image itself to show staleness
+- Or add a small indicator (e.g., "?" instead of "...") to differentiate
+- **Pros:** Simple, removes dead code
+- **Cons:** Need to decide on visual differentiation
+- **Effort:** Small
+- **Risk:** Low
+
+### Solution B: Fix the drawing code
+- Replace lockFocus/unlockFocus with proper overlay drawing in a new NSImage drawingHandler
+- **Pros:** Preserves intended design
+- **Cons:** More code, uses pattern that was already buggy
+- **Effort:** Small
+- **Risk:** Low
+
+## Recommended Action
+
+Solution A — the simplest fix. The stale icon should look visually distinct from loading. Consider drawing the loading icon at reduced alpha or using a "?" character instead of "...".
+
+## Technical Details
+
+- **Affected files:** `ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift`
+
+## Acceptance Criteria
+
+- [ ] Stale state is visually distinguishable from loading state
+- [ ] No deprecated lockFocus/unlockFocus usage
+- [ ] updateIcon correctly routes to stale visual when appropriate
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/011-complete-p1-combine-latest-redundant-redraws.md
+++ b/todos/011-complete-p1-combine-latest-redundant-redraws.md
@@ -1,0 +1,59 @@
+---
+status: complete
+priority: p1
+issue_id: "011"
+tags: [code-review, performance, combine, ui]
+dependencies: []
+---
+
+# combineLatest of 4 Publishers Causes Redundant Icon Redraws
+
+## Problem Statement
+
+`MenuBarController.setupObservers()` uses `combineLatest` with 4 publishers (`latestUsage`, `consecutiveFailures`, `lastSuccessfulFetch`, `isAuthenticated`). After each poll, up to 3 of these publishers fire sequentially, causing 3 redundant `updateIcon()` calls and 3 redundant `NSImage` allocations per poll cycle.
+
+Found by: Performance Oracle (CRITICAL-3), Code Simplicity Reviewer
+
+## Findings
+
+- **Location:** `MenuBarController.swift:50-62`
+- **Evidence:** `combineLatest` fires the sink for every individual publisher change. A single poll updates `latestUsage`, `consecutiveFailures`, and `lastSuccessfulFetch` — that's 3 sink invocations.
+- **Impact:** 3x unnecessary NSImage creation per poll (every 2 minutes). Each image involves text measurement and drawing.
+- **Simplicity note:** `updateIcon()` only reads `usage` and `isAuthenticated`. The other two values (`consecutiveFailures`, `lastSuccessfulFetch`) are accessed directly from `usageService` inside `updateIcon()` anyway.
+
+## Proposed Solutions
+
+### Solution A: Observe only 2 publishers (Recommended)
+- Use `combineLatest` with only `$latestUsage` and `$isAuthenticated`
+- Access `consecutiveFailures` and `lastSuccessfulFetch` directly from `usageService` inside `updateIcon()`
+- **Pros:** Eliminates 2 of 3 redundant redraws, simplifies code
+- **Cons:** None — the values are already read from the service
+- **Effort:** Small
+- **Risk:** Low
+
+### Solution B: Add throttle/debounce
+- Add `.debounce(for: .milliseconds(100))` to the pipeline
+- **Pros:** Coalesces all publisher changes into one redraw
+- **Cons:** Adds latency, more complex, still subscribes to unused publishers
+- **Effort:** Small
+- **Risk:** Low
+
+## Recommended Action
+
+Solution A — observe only the 2 publishers that actually need to trigger redraws.
+
+## Technical Details
+
+- **Affected files:** `ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift`
+
+## Acceptance Criteria
+
+- [ ] `setupObservers()` uses `combineLatest` with only 2 publishers
+- [ ] Icon still updates correctly for all state changes
+- [ ] No redundant redraws per poll cycle
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/012-complete-p1-no-session-cookie-expiration-tracking.md
+++ b/todos/012-complete-p1-no-session-cookie-expiration-tracking.md
@@ -1,0 +1,60 @@
+---
+status: complete
+priority: p1
+issue_id: "012"
+tags: [code-review, security, authentication]
+dependencies: []
+---
+
+# No Session Cookie Expiration Tracking
+
+## Problem Statement
+
+The app captures the `sessionKey` cookie value and stores it in Keychain, but never stores or checks the cookie's `expiresDate`. If the cookie expires, the app continues sending invalid credentials until the server returns 401/403, which triggers the auth failure callback. There is no proactive expiration check.
+
+Found by: Security Sentinel (HIGH)
+
+## Findings
+
+- **Location:** `AuthManager.swift` — `onSessionKeyCaptured()` saves only `cookie.value`, discards `cookie.expiresDate`
+- **Impact:** After cookie expiration, the app makes failed API calls for multiple poll intervals before `consecutiveFailures` triggers the error state. User sees stale data or loading state instead of a clear "session expired" message.
+- **Current mitigation:** The `onAuthFailure` callback in UsageService handles 401/403 by stopping polling and calling `handleAuthFailure()`. This is reactive rather than proactive.
+
+## Proposed Solutions
+
+### Solution A: Store and check expiration date (Recommended)
+- Save `cookie.expiresDate` to Keychain or UserDefaults alongside the session key
+- Before each poll, check if the cookie has expired
+- If expired, proactively trigger re-auth flow
+- **Pros:** Better UX, avoids unnecessary failed requests
+- **Cons:** Slight additional complexity
+- **Effort:** Small
+- **Risk:** Low
+
+### Solution B: Accept current reactive approach
+- The 401/403 handling already works
+- Just ensure the error state clearly tells the user to re-authenticate
+- **Pros:** No code change needed
+- **Cons:** User sees stale/error state for a poll cycle before re-auth prompt
+- **Effort:** None
+- **Risk:** Low — current behavior is functional, just not optimal
+
+## Recommended Action
+
+Solution A — store expiration and check proactively. This provides cleaner UX.
+
+## Technical Details
+
+- **Affected files:** `AuthManager.swift`, `UsageService.swift`, possibly `KeychainService.swift`
+
+## Acceptance Criteria
+
+- [ ] Cookie expiration date is stored alongside session key
+- [ ] Polling checks expiration before making API calls
+- [ ] Expired session triggers re-auth prompt proactively
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/013-complete-p2-overly-broad-domain-whitelist.md
+++ b/todos/013-complete-p2-overly-broad-domain-whitelist.md
@@ -1,0 +1,56 @@
+---
+status: complete
+priority: p2
+issue_id: "013"
+tags: [code-review, security, authentication]
+dependencies: []
+---
+
+# Overly Broad Domain Whitelist in AuthManager
+
+## Problem Statement
+
+`AuthManager.isAllowedDomain()` whitelists `.google.com`, `.apple.com`, `.cloudflare.com` in addition to `.claude.ai` and `.anthropic.com`. These broad domains allow the embedded WKWebView to navigate to any subdomain of Google, Apple, and Cloudflare — increasing the attack surface for potential phishing or redirect attacks within the login flow.
+
+Found by: Security Sentinel (MEDIUM)
+
+## Findings
+
+- **Location:** `AuthManager.swift` — `isAllowedDomain()` method
+- **Evidence:** Domain suffixes like `.google.com` match any subdomain (e.g., `evil.google.com` if such a subdomain were compromised)
+- **Context:** These domains are needed for OAuth flows (Google SSO) and Cloudflare challenges. The broad matching is a trade-off for functionality.
+- **Impact:** Medium — the WKWebView is only shown during login, and the user is already interacting with it. Risk is limited to the login window context.
+
+## Proposed Solutions
+
+### Solution A: Tighten to specific subdomains (Recommended)
+- Replace `.google.com` with `accounts.google.com`, `oauth2.google.com`
+- Replace `.cloudflare.com` with `challenges.cloudflare.com`
+- Keep `.claude.ai` and `.anthropic.com` as-is
+- **Pros:** Reduced attack surface
+- **Cons:** May break if OAuth provider changes subdomains
+- **Effort:** Small
+- **Risk:** Medium — could break login if subdomains change
+
+### Solution B: Keep current approach with documentation
+- Add comments explaining why broad domains are needed
+- **Pros:** No risk of breaking login
+- **Cons:** Broader attack surface remains
+- **Effort:** Minimal
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `AuthManager.swift`
+
+## Acceptance Criteria
+
+- [ ] Domain whitelist is as narrow as possible while still supporting OAuth flows
+- [ ] Login flow works with Google SSO and Cloudflare challenges
+- [ ] Domains are documented with rationale
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/014-complete-p2-force-unwrap-crash-risks.md
+++ b/todos/014-complete-p2-force-unwrap-crash-risks.md
@@ -1,0 +1,47 @@
+---
+status: complete
+priority: p2
+issue_id: "014"
+tags: [code-review, security, crash-safety]
+dependencies: []
+---
+
+# Force-Unwrap Crash Risks in URL Construction
+
+## Problem Statement
+
+Multiple places in the codebase use force-unwrap (`!`) when constructing URLs from strings that include user-supplied or Keychain-stored data. If the data contains invalid URL characters, the app crashes.
+
+Found by: Security Sentinel (MEDIUM), Pattern Recognition Specialist (LOW)
+
+## Findings
+
+- **Location 1:** `UsageService.swift` — `URL(string: "https://claude.ai/api/organizations/\(orgId)/usage")!`
+  - `orgId` comes from Keychain. If corrupted or tampered, URL construction crashes.
+- **Location 2:** `AuthManager.swift` — `URL(string: "https://claude.ai/api/organizations")!`
+  - This one is a literal string so it's safe, but the pattern is fragile.
+- **Impact:** App crash if orgId contains spaces, special characters, or is empty.
+
+## Proposed Solutions
+
+### Solution A: Guard with optional binding (Recommended)
+- Replace `URL(string:)!` with `guard let url = URL(string:) else { return }` or log an error
+- **Pros:** Prevents crashes, graceful degradation
+- **Cons:** Slightly more verbose
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `UsageService.swift`, `AuthManager.swift`
+
+## Acceptance Criteria
+
+- [ ] No force-unwraps on URL construction with dynamic data
+- [ ] Invalid URLs handled gracefully (log + early return)
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/015-complete-p2-duplicated-http-request-headers.md
+++ b/todos/015-complete-p2-duplicated-http-request-headers.md
@@ -1,0 +1,54 @@
+---
+status: complete
+priority: p2
+issue_id: "015"
+tags: [code-review, architecture, duplication]
+dependencies: []
+---
+
+# Duplicated HTTP Request Headers Between Services
+
+## Problem Statement
+
+Both `AuthManager` and `UsageService` independently construct the same Cloudflare bypass and browser-mimicking HTTP headers. This duplication means header changes must be applied in two places, risking drift.
+
+Found by: Pattern Recognition Specialist (HIGH), Architecture Strategist (LOW), Code Simplicity Reviewer
+
+## Findings
+
+- **Location 1:** `AuthManager.swift` — `fetchOrganization()` sets User-Agent, Accept, Referer, Cookie headers
+- **Location 2:** `UsageService.swift` — `pollUsage()` sets the same headers
+- **Impact:** Maintenance burden — if Claude.ai changes required headers, both files must be updated. Easy to miss one.
+
+## Proposed Solutions
+
+### Solution A: Extract shared request builder (Recommended)
+- Add a static method or free function: `makeAuthenticatedRequest(url: URL, sessionKey: String) -> URLRequest`
+- Both services call this shared function
+- **Pros:** Single source of truth, DRY
+- **Cons:** Adds a shared dependency
+- **Effort:** Small
+- **Risk:** Low
+
+### Solution B: Move to URLSession configuration
+- Set common headers on the URLSession configuration's `httpAdditionalHeaders`
+- **Pros:** Automatic for all requests
+- **Cons:** Session-level headers may not be appropriate for all requests
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `AuthManager.swift`, `UsageService.swift`, potentially a new shared helper
+
+## Acceptance Criteria
+
+- [ ] HTTP headers defined in one place
+- [ ] Both AuthManager and UsageService use the shared definition
+- [ ] No header drift between the two
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/016-complete-p2-silent-error-swallowing.md
+++ b/todos/016-complete-p2-silent-error-swallowing.md
@@ -1,0 +1,58 @@
+---
+status: complete
+priority: p2
+issue_id: "016"
+tags: [code-review, quality, debugging, logging]
+dependencies: []
+---
+
+# Silent Error Swallowing — No Logging Throughout
+
+## Problem Statement
+
+Errors from Keychain operations, network requests, JSON decoding, and notification authorization are all silently ignored. This makes debugging production issues nearly impossible — users report "it stopped working" with no diagnostic information available.
+
+Found by: Pattern Recognition Specialist (HIGH)
+
+## Findings
+
+- **KeychainService:** `save()`, `delete()` silently ignore `OSStatus` errors
+- **UsageService:** `pollUsage()` catches all errors in a generic `catch { }` with no logging
+- **AuthManager:** `fetchOrganization()` catches errors silently
+- **SettingsView:** `SMAppService.register()/unregister()` catches silently
+- **Impact:** When things go wrong, there's no way to diagnose what failed. Users and developers are blind.
+
+## Proposed Solutions
+
+### Solution A: Add os.Logger (Recommended)
+- Use `os.Logger` (macOS 11+) for structured, privacy-aware logging
+- Create a shared logger: `Logger(subsystem: Bundle.main.bundleIdentifier!, category: "...")`
+- Log errors at `.error` level, state changes at `.info` level
+- **Pros:** System-integrated, privacy-aware, viewable in Console.app
+- **Cons:** Adds logging code throughout
+- **Effort:** Medium
+- **Risk:** Low
+
+### Solution B: print() for development
+- Add `print()` statements for errors
+- **Pros:** Quick, simple
+- **Cons:** Not available in production builds, no structured logging
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** All service files
+
+## Acceptance Criteria
+
+- [ ] Keychain errors are logged with OSStatus codes
+- [ ] Network errors are logged with error descriptions
+- [ ] JSON decoding failures are logged with context
+- [ ] Logs are viewable in Console.app
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/017-complete-p2-auth-manager-uses-shared-urlsession.md
+++ b/todos/017-complete-p2-auth-manager-uses-shared-urlsession.md
@@ -1,0 +1,46 @@
+---
+status: complete
+priority: p2
+issue_id: "017"
+tags: [code-review, security, networking]
+dependencies: []
+---
+
+# AuthManager Uses URLSession.shared for Sensitive Requests
+
+## Problem Statement
+
+`AuthManager.fetchOrganization()` uses `URLSession.shared` to make authenticated API calls. The shared session has default cookie storage enabled, which means the session cookie could be stored in the default cookie jar and potentially leaked to other requests or read by other code using the shared session.
+
+Found by: Security Sentinel (MEDIUM)
+
+## Findings
+
+- **Location:** `AuthManager.swift` — `fetchOrganization()` uses `URLSession.shared.data(for:)`
+- **Contrast:** `UsageService` correctly creates a custom `URLSession` with `httpShouldSetCookies = false`
+- **Impact:** The session cookie sent in the Authorization/Cookie header could be stored by the shared session's cookie storage, persisting beyond the intended scope.
+
+## Proposed Solutions
+
+### Solution A: Use custom URLSession with cookie storage disabled (Recommended)
+- Create a private `URLSession` in AuthManager with `httpShouldSetCookies = false`
+- Or reuse the same configuration pattern as UsageService
+- **Pros:** Consistent security posture, no cookie leakage
+- **Cons:** Minimal — one more URLSession instance
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `AuthManager.swift`
+
+## Acceptance Criteria
+
+- [ ] AuthManager does not use URLSession.shared for authenticated requests
+- [ ] Cookie storage is disabled on the session used for API calls
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/018-complete-p2-dateformatter-allocation-per-render.md
+++ b/todos/018-complete-p2-dateformatter-allocation-per-render.md
@@ -1,0 +1,45 @@
+---
+status: complete
+priority: p2
+issue_id: "018"
+tags: [code-review, performance, swiftui]
+dependencies: []
+---
+
+# DateFormatter Allocated on Every Popover Render
+
+## Problem Statement
+
+`UsagePopoverView.formatResetDate()` creates a new `DateFormatter` instance on every call. `DateFormatter` allocation is expensive (~5ms per init) and this method is called multiple times during each SwiftUI view render.
+
+Found by: Performance Oracle (OPT-1), Pattern Recognition Specialist (LOW)
+
+## Findings
+
+- **Location:** `UsagePopoverView.swift` — `formatResetDate()` method
+- **Evidence:** `let formatter = DateFormatter()` inside the method body
+- **Impact:** Measurable view render latency on each popover open and during state updates
+
+## Proposed Solutions
+
+### Solution A: Static DateFormatter (Recommended)
+- Move DateFormatter to a `static let` property
+- **Pros:** Zero allocation on each call, standard Swift pattern
+- **Cons:** None
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `UsagePopoverView.swift`
+
+## Acceptance Criteria
+
+- [ ] DateFormatter is allocated once (static or cached)
+- [ ] Formatting still works correctly
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/019-complete-p2-redundant-text-measurement.md
+++ b/todos/019-complete-p2-redundant-text-measurement.md
@@ -1,0 +1,46 @@
+---
+status: complete
+priority: p2
+issue_id: "019"
+tags: [code-review, performance, drawing]
+dependencies: []
+---
+
+# Redundant Text Measurement in makeBatteryIcon
+
+## Problem Statement
+
+`makeBatteryIcon()` in `MenuBarController.swift` measures text strings twice — once in `computeIconWidth()` to calculate the total width, then again in the drawing handler when positioning text. This results in 8 `NSString.size(withAttributes:)` calls when 4 would suffice.
+
+Found by: Performance Oracle (CRITICAL-2)
+
+## Findings
+
+- **Location:** `MenuBarController.swift` — `makeBatteryIcon()` and `computeIconWidth()`
+- **Evidence:** `computeIconWidth()` measures all 4 text strings, then the drawing handler re-measures them for positioning
+- **Impact:** Each text measurement involves font metric calculations. Doubled work on every icon update.
+
+## Proposed Solutions
+
+### Solution A: Compute sizes once and pass to drawing handler (Recommended)
+- Calculate all text sizes upfront, pass them into the drawing handler
+- Use the same sizes for both width computation and positioning
+- **Pros:** Eliminates 4 redundant measurements
+- **Cons:** Slightly different code structure
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `MenuBarController.swift`
+
+## Acceptance Criteria
+
+- [ ] Each text string measured only once per icon render
+- [ ] Icon still renders correctly at all percentage values
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/020-complete-p3-is-keychain-locked-redundant.md
+++ b/todos/020-complete-p3-is-keychain-locked-redundant.md
@@ -1,0 +1,45 @@
+---
+status: complete
+priority: p3
+issue_id: "020"
+tags: [code-review, simplicity, cleanup]
+dependencies: []
+---
+
+# isKeychainLocked Property is Redundant
+
+## Problem Statement
+
+`KeychainService.isKeychainLocked` performs a Keychain query with `kSecReturnData` just to check if the Keychain is accessible. This is redundant because `read()` already returns `nil` when the Keychain is locked. The check in `UsageService.pollUsage()` can simply use the existing `read()` guard.
+
+Found by: Code Simplicity Reviewer, Performance Oracle (OPT-4/5)
+
+## Findings
+
+- **Location:** `KeychainService.swift` — `isKeychainLocked` property
+- **Location:** `UsageService.swift` — `if keychain.isKeychainLocked { return }` before `guard let sessionKey = keychain.read(...)`
+- **Impact:** Performs an unnecessary full Keychain data retrieval just to check status, immediately followed by the actual reads that would fail naturally if locked.
+
+## Proposed Solutions
+
+### Solution A: Remove isKeychainLocked (Recommended)
+- Delete the `isKeychainLocked` property
+- Remove the guard in `pollUsage()` — the subsequent `guard let sessionKey` handles it
+- **Pros:** Less code, one fewer Keychain round-trip per poll
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `KeychainService.swift`, `UsageService.swift`
+
+## Acceptance Criteria
+
+- [ ] `isKeychainLocked` property removed
+- [ ] Polling still gracefully handles locked Keychain via read() returning nil
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/021-complete-p3-static-icons-not-cached.md
+++ b/todos/021-complete-p3-static-icons-not-cached.md
@@ -1,0 +1,42 @@
+---
+status: complete
+priority: p3
+issue_id: "021"
+tags: [code-review, performance, caching]
+dependencies: []
+---
+
+# Static Icons Recreated on Every Call
+
+## Problem Statement
+
+`makeUnauthenticatedIcon()`, `makeLoadingIcon()`, and `makeErrorIcon()` create new `NSImage` instances every time they're called, even though their output never changes. These could be cached as static properties.
+
+Found by: Performance Oracle (OPT-2)
+
+## Findings
+
+- **Location:** `MenuBarController.swift` — `makeUnauthenticatedIcon()`, `makeLoadingIcon()`, `makeErrorIcon()`
+- **Impact:** Minor — these are called infrequently (only on state transitions). But caching is trivial.
+
+## Proposed Solutions
+
+### Solution A: Lazy static properties (Recommended)
+- Create icons once as `lazy var` properties on MenuBarController
+- **Pros:** Zero-cost after first call
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `MenuBarController.swift`
+
+## Acceptance Criteria
+
+- [ ] Static icons created once and reused
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/022-complete-p3-hardcoded-strings-and-magic-numbers.md
+++ b/todos/022-complete-p3-hardcoded-strings-and-magic-numbers.md
@@ -1,0 +1,44 @@
+---
+status: complete
+priority: p3
+issue_id: "022"
+tags: [code-review, quality, maintainability]
+dependencies: []
+---
+
+# Hardcoded Keychain Keys and Magic Numbers
+
+## Problem Statement
+
+Keychain key strings (`"sessionKey"`, `"organizationId"`) are hardcoded as string literals at each call site. Polling intervals (`120`, `300`, `600`, `1800`) and thresholds (`10`, `3`, `20`) are magic numbers without named constants.
+
+Found by: Pattern Recognition Specialist (MEDIUM)
+
+## Findings
+
+- **Keychain keys:** `"sessionKey"` used in AuthManager + UsageService, `"organizationId"` used in AuthManager + UsageService — any typo causes silent failure
+- **Magic numbers:** `660` (login timeout), `120/300/600/1800` (polling intervals), `10` (error threshold), `3` (stale threshold), `20` (notification threshold default)
+
+## Proposed Solutions
+
+### Solution A: Named constants (Recommended)
+- Add an enum or extension with static let constants for Keychain keys
+- Add named constants for polling intervals and thresholds
+- **Pros:** Compile-time safety for keys, self-documenting code
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `KeychainService.swift` (or new constants), `AuthManager.swift`, `UsageService.swift`, `MenuBarController.swift`
+
+## Acceptance Criteria
+
+- [ ] Keychain keys defined as constants (no string literals at call sites)
+- [ ] Polling intervals and thresholds have named constants
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |

--- a/todos/023-complete-p3-app-lifecycle-cleanup.md
+++ b/todos/023-complete-p3-app-lifecycle-cleanup.md
@@ -1,0 +1,50 @@
+---
+status: complete
+priority: p3
+issue_id: "023"
+tags: [code-review, simplicity, cleanup]
+dependencies: []
+---
+
+# App Lifecycle Cleanup — Unnecessary Patterns
+
+## Problem Statement
+
+Several patterns in the app lifecycle are over-engineered or no-ops:
+1. `applicationWillTerminate` wraps `stopPolling()` in a `Task { @MainActor }` — the process is terminating, this task may never execute
+2. `signOut()` uses `async/await` wrapping `withCheckedContinuation` for `WKWebsiteDataStore.removeData` — this could just be fire-and-forget
+3. Login timeout (660 seconds) with a cancellation task is over-engineered for a simple UX guard
+
+Found by: Code Simplicity Reviewer, Performance Oracle (OPT-7)
+
+## Findings
+
+- **applicationWillTerminate:** `Task { @MainActor in usageService?.stopPolling() }` — the process exits before the task runs. Timer invalidation is unnecessary since the process is dying.
+- **signOut:** Wraps callback-based API in `withCheckedContinuation` just to `await` it. The caller doesn't need to wait for cookie deletion to complete.
+- **Login timeout:** Task.sleep + cancellation tracking for something that could be a simple DispatchQueue.main.asyncAfter.
+
+## Proposed Solutions
+
+### Solution A: Simplify all three (Recommended)
+- Remove `applicationWillTerminate` body (process cleanup is automatic)
+- Make `signOut()` synchronous — call `removeData` fire-and-forget
+- Simplify login timeout to a single dispatch or remove if unnecessary
+- **Pros:** Less code, clearer intent
+- **Effort:** Small
+- **Risk:** Low
+
+## Technical Details
+
+- **Affected files:** `ClaudeBatteryApp.swift`, `AuthManager.swift`
+
+## Acceptance Criteria
+
+- [ ] applicationWillTerminate is simplified or removed
+- [ ] signOut doesn't use unnecessary async/await
+- [ ] Login timeout is simpler or removed
+
+## Work Log
+
+| Date | Action | Notes |
+|------|--------|-------|
+| 2026-02-15 | Created | From code review finding |


### PR DESCRIPTION
## Summary
- macOS menu bar widget that displays Claude Pro/Max usage as a battery icon
- WKWebView cookie-based authentication with claude.ai
- Real-time polling of undocumented usage API with adaptive intervals
- Battery icon shows weekly quota fill, percentage, reset time, session bar, and session reset
- Popover with detailed usage breakdown (weekly, session, per-model)
- Settings for launch at login, notifications, and usage threshold
- 15 code review findings resolved (security, performance, architecture)
- Authentication bug fix: sign-in button now shows correctly for unauthenticated users

## Test plan
- [ ] Build and run in Xcode
- [ ] Verify sign-in button appears on first launch
- [ ] Complete authentication via claude.ai login
- [ ] Verify battery icon updates with usage data
- [ ] Check popover shows weekly/session breakdown
- [ ] Test right-click context menu (Settings, Quit)
- [ ] Verify launch at login toggle works
