### PR TITLE
fix: multi-org selection and login reliability

### DIFF
--- a/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
+++ b/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
@@ -33,7 +33,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         storage = StorageService()
         accountStore = AccountStore(storage: storage)
-        accountStore.clearSessionExpirations()
         authManager = AuthManager(storage: storage, accountStore: accountStore)
         usageService = UsageService(storage: storage, accountStore: accountStore)
 

--- a/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
+++ b/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
@@ -33,6 +33,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         storage = StorageService()
         accountStore = AccountStore(storage: storage)
+        accountStore.clearSessionExpirations()
         authManager = AuthManager(storage: storage, accountStore: accountStore)
         usageService = UsageService(storage: storage, accountStore: accountStore)
 

--- a/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
@@ -38,23 +38,6 @@ class AccountStore: ObservableObject {
         }
     }
 
-    // MARK: - Migration
-
-    /// Clear stale sessionKeyExpiration from all accounts.
-    /// Non-persistent WKWebView store produces unreliable expiresDate values;
-    /// session validity is now determined solely by API 401/403 responses.
-    func clearSessionExpirations() {
-        var changed = false
-        for i in accounts.indices where accounts[i].sessionKeyExpiration != nil {
-            accounts[i].sessionKeyExpiration = nil
-            changed = true
-        }
-        if changed {
-            persist()
-            logger.info("Cleared stale sessionKeyExpiration from stored accounts")
-        }
-    }
-
     // MARK: - Mutations
 
     func addAccount(_ account: Account) -> Bool {
@@ -100,10 +83,9 @@ class AccountStore: ObservableObject {
         logger.info("Switched to account \(id.uuidString)")
     }
 
-    func updateSessionKey(_ id: UUID, _ sessionKey: String, expiration: Date? = nil) {
+    func updateSessionKey(_ id: UUID, _ sessionKey: String) {
         guard let index = accounts.firstIndex(where: { $0.id == id }) else { return }
         accounts[index].sessionKey = sessionKey
-        accounts[index].sessionKeyExpiration = expiration
         persist()
     }
 

--- a/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
@@ -38,6 +38,23 @@ class AccountStore: ObservableObject {
         }
     }
 
+    // MARK: - Migration
+
+    /// Clear stale sessionKeyExpiration from all accounts.
+    /// Non-persistent WKWebView store produces unreliable expiresDate values;
+    /// session validity is now determined solely by API 401/403 responses.
+    func clearSessionExpirations() {
+        var changed = false
+        for i in accounts.indices where accounts[i].sessionKeyExpiration != nil {
+            accounts[i].sessionKeyExpiration = nil
+            changed = true
+        }
+        if changed {
+            persist()
+            logger.info("Cleared stale sessionKeyExpiration from stored accounts")
+        }
+    }
+
     // MARK: - Mutations
 
     func addAccount(_ account: Account) -> Bool {

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -28,7 +28,6 @@ class AuthManager: NSObject, ObservableObject {
     private var hasCapturedSession = false
     // internal for @testable access in AuthManagerTests
     var pendingSessionKey: String?
-    private var pendingExpiration: Date?
 
     init(storage: StorageService, accountStore: AccountStore, session: any HTTPDataFetching = ClaudeAPI.session) {
         self.storage = storage
@@ -139,7 +138,6 @@ class AuthManager: NSObject, ObservableObject {
                     logger.info("Session cookie captured via JavaScript fallback")
                     self.hasCapturedSession = true
                     self.pendingSessionKey = value
-                    self.pendingExpiration = nil  // JS cookies don't expose expiration
                     self.loginState = .signingIn
                     self.cookiePollTimer?.invalidate()
                     self.cookiePollTimer = nil
@@ -184,7 +182,6 @@ class AuthManager: NSObject, ObservableObject {
 
         hasCapturedSession = true
         pendingSessionKey = cookie.value
-        pendingExpiration = nil  // Don't trust cookie.expiresDate from non-persistent store
         loginState = .signingIn
         cookiePollTimer?.invalidate()
         cookiePollTimer = nil
@@ -255,11 +252,11 @@ class AuthManager: NSObject, ObservableObject {
             let chosenOrg: Organization
             if orgs.count == 1 {
                 chosenOrg = orgs[0]
-            } else if let activeOrgId = accountStore.activeAccount?.organizationId,
-                      let match = orgs.first(where: { $0.uuid == activeOrgId }) {
-                // Re-auth: auto-select the active account's org if still in the list
+            } else if let existingAccount = accountStore.accounts.first(where: { acct in orgs.contains(where: { $0.uuid == acct.organizationId }) }),
+                      let match = orgs.first(where: { $0.uuid == existingAccount.organizationId }) {
+                // Re-auth: auto-select if any existing account's org is in the list
                 chosenOrg = match
-                logger.info("Re-auth auto-selected org: \(match.displayName)")
+                logger.info("Re-auth auto-selected org for account \(existingAccount.displayName): \(match.displayName)")
             } else {
                 // Multiple orgs, no auto-select match — show picker
                 guard let picked = await showOrgPicker(orgs: orgs) else {
@@ -278,8 +275,7 @@ class AuthManager: NSObject, ObservableObject {
             let account = Account(
                 email: email,
                 sessionKey: sessionKey,
-                organizationId: chosenOrg.uuid,
-                sessionKeyExpiration: pendingExpiration
+                organizationId: chosenOrg.uuid
             )
 
             if accountStore.addAccount(account) {
@@ -287,7 +283,7 @@ class AuthManager: NSObject, ObservableObject {
                 logger.info("Account added and activated: \(account.displayName)")
             } else if let existing = accountStore.accounts.first(where: { $0.organizationId == chosenOrg.uuid }) {
                 // Re-authentication: update session key on existing account
-                accountStore.updateSessionKey(existing.id, sessionKey, expiration: pendingExpiration)
+                accountStore.updateSessionKey(existing.id, sessionKey)
                 accountStore.switchTo(existing.id)
                 logger.info("Re-authenticated existing account: \(existing.displayName)")
             } else {
@@ -299,7 +295,6 @@ class AuthManager: NSObject, ObservableObject {
 
             // Success — clean up and close window
             pendingSessionKey = nil
-            pendingExpiration = nil
             loginState = .idle
             stopLoginWindow()
         } catch {
@@ -312,7 +307,6 @@ class AuthManager: NSObject, ObservableObject {
 
     private func handleOrgDiscoveryFailure(_ message: String) {
         pendingSessionKey = nil
-        pendingExpiration = nil
         hasCapturedSession = false
         loginState = .error(message)
     }
@@ -340,7 +334,12 @@ class AuthManager: NSObject, ObservableObject {
 
             let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 300, height: 28), pullsDown: false)
             for (index, org) in orgs.enumerated() {
-                let title = org.displayName == "Organization" ? "Organization \(index + 1)" : org.displayName
+                var title = org.displayName == "Organization" ? "Organization \(index + 1)" : org.displayName
+                // Disambiguate if another org has the same display name
+                let duplicateCount = orgs.prefix(index).filter { $0.displayName == org.displayName && org.displayName != "Organization" }.count
+                if duplicateCount > 0 {
+                    title = "\(title) (\(duplicateCount + 1))"
+                }
                 popup.addItem(withTitle: title)
             }
             alert.accessoryView = popup
@@ -468,7 +467,6 @@ extension AuthManager: WKNavigationDelegate {
             self.loginState = .idle
             self.hasCapturedSession = false
             self.pendingSessionKey = nil
-            self.pendingExpiration = nil
             self.stopLoginWindow()
         }
     }
@@ -500,7 +498,6 @@ extension AuthManager: NSWindowDelegate {
         if loginState == .signingIn {
             hasCapturedSession = false
             pendingSessionKey = nil
-            pendingExpiration = nil
         }
         loginState = .idle
 

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -52,9 +52,9 @@ class AuthManager: NSObject, ObservableObject {
 
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
-        config.applicationNameForUserAgent = ClaudeAPI.safariUserAgentSuffix
 
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 640), configuration: config)
+        webView.customUserAgent = ClaudeAPI.safariUserAgent
         webView.navigationDelegate = self
         self.loginWebView = webView
 
@@ -184,7 +184,7 @@ class AuthManager: NSObject, ObservableObject {
 
         hasCapturedSession = true
         pendingSessionKey = cookie.value
-        pendingExpiration = cookie.expiresDate
+        pendingExpiration = nil  // Don't trust cookie.expiresDate from non-persistent store
         loginState = .signingIn
         cookiePollTimer?.invalidate()
         cookiePollTimer = nil
@@ -251,20 +251,41 @@ class AuthManager: NSObject, ObservableObject {
                 return
             }
 
+            // Determine which org to use
+            let chosenOrg: Organization
+            if orgs.count == 1 {
+                chosenOrg = orgs[0]
+            } else if let activeOrgId = accountStore.activeAccount?.organizationId,
+                      let match = orgs.first(where: { $0.uuid == activeOrgId }) {
+                // Re-auth: auto-select the active account's org if still in the list
+                chosenOrg = match
+                logger.info("Re-auth auto-selected org: \(match.displayName)")
+            } else {
+                // Multiple orgs, no auto-select match — show picker
+                guard let picked = await showOrgPicker(orgs: orgs) else {
+                    // User cancelled the picker
+                    handleOrgDiscoveryFailure("Sign-in cancelled.")
+                    return
+                }
+                chosenOrg = picked
+            }
+
+            guard !Task.isCancelled else { return }
+
             // Try to extract email from org response
-            let email = extractEmail(from: data) ?? "Account \(accountStore.accounts.count + 1)"
+            let email = extractEmail(from: orgs, rawData: data) ?? "Account \(accountStore.accounts.count + 1)"
 
             let account = Account(
                 email: email,
                 sessionKey: sessionKey,
-                organizationId: orgs[0].uuid,
+                organizationId: chosenOrg.uuid,
                 sessionKeyExpiration: pendingExpiration
             )
 
             if accountStore.addAccount(account) {
                 accountStore.switchTo(account.id)
                 logger.info("Account added and activated: \(account.displayName)")
-            } else if let existing = accountStore.accounts.first(where: { $0.organizationId == orgs[0].uuid }) {
+            } else if let existing = accountStore.accounts.first(where: { $0.organizationId == chosenOrg.uuid }) {
                 // Re-authentication: update session key on existing account
                 accountStore.updateSessionKey(existing.id, sessionKey, expiration: pendingExpiration)
                 accountStore.switchTo(existing.id)
@@ -306,18 +327,54 @@ class AuthManager: NSObject, ObservableObject {
         alert.beginSheetModal(for: window)
     }
 
-    private func extractEmail(from data: Data) -> String? {
-        // Try to extract email from the organizations response, checking multiple possible keys
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
-              let first = json.first else { return nil }
+    private func showOrgPicker(orgs: [Organization]) async -> Organization? {
+        guard let window = loginWindowController?.window else { return nil }
 
-        let emailKeys = ["email_address", "email", "billing_email", "primary_email"]
-        for key in emailKeys {
+        return await withCheckedContinuation { continuation in
+            let alert = NSAlert()
+            alert.messageText = "Choose Organization"
+            alert.informativeText = "Multiple organizations found. Select which one to monitor."
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Select")
+            alert.addButton(withTitle: "Cancel")
+
+            let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 300, height: 28), pullsDown: false)
+            for (index, org) in orgs.enumerated() {
+                let title = org.displayName == "Organization" ? "Organization \(index + 1)" : org.displayName
+                popup.addItem(withTitle: title)
+            }
+            alert.accessoryView = popup
+
+            alert.beginSheetModal(for: window) { response in
+                if response == .alertFirstButtonReturn {
+                    let selectedIndex = popup.indexOfSelectedItem
+                    guard selectedIndex >= 0, selectedIndex < orgs.count else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    continuation.resume(returning: orgs[selectedIndex])
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    private func extractEmail(from orgs: [Organization], rawData: Data) -> String? {
+        // Prefer the enriched model's emailAddress field
+        for org in orgs {
+            if let email = org.emailAddress, !email.isEmpty {
+                return email
+            }
+        }
+        // Fallback: search raw JSON for additional email keys not in the model
+        guard let json = try? JSONSerialization.jsonObject(with: rawData) as? [[String: Any]],
+              let first = json.first else { return nil }
+        for key in ["email", "billing_email", "primary_email"] {
             if let email = first[key] as? String, !email.isEmpty {
                 return email
             }
         }
-        // Try nested billing object
         if let billing = first["billing"] as? [String: Any],
            let email = billing["email"] as? String, !email.isEmpty {
             return email
@@ -464,4 +521,25 @@ extension AuthManager: NSWindowDelegate {
 
 struct Organization: Codable {
     let uuid: String
+    let name: String?
+    let billingType: String?
+    let emailAddress: String?
+
+    var displayName: String {
+        if let name, !name.isEmpty {
+            let sanitized = name.filter { !$0.isNewline && $0 != "\u{200F}" && $0 != "\u{200E}" }
+            return String(sanitized.prefix(100))
+        }
+        if let billingType, !billingType.isEmpty {
+            return billingType.capitalized
+        }
+        return "Organization"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case uuid
+        case name
+        case billingType = "billing_type"
+        case emailAddress = "email_address"
+    }
 }

--- a/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
@@ -10,8 +10,6 @@ enum ClaudeAPI {
 
     static let safariUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) \(safariVersionToken) Safari/605.1.15"
 
-    static let safariUserAgentSuffix = "\(safariVersionToken) Safari/605.1.15"
-
     static let session: URLSession = {
         let config = URLSessionConfiguration.ephemeral
         config.httpShouldSetCookies = false

--- a/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
@@ -14,13 +14,12 @@ struct Account: Codable, Identifiable, Equatable {
     let addedDate: Date
     var notificationThreshold: Double
     var didNotifyBelowThreshold: Bool
-    var sessionKeyExpiration: Date?
 
     var displayName: String {
         nickname ?? email
     }
 
-    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, sessionKeyExpiration: Date? = nil) {
+    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false) {
         self.id = id
         self.email = email
         self.sessionKey = sessionKey
@@ -29,7 +28,6 @@ struct Account: Codable, Identifiable, Equatable {
         self.addedDate = addedDate
         self.notificationThreshold = notificationThreshold
         self.didNotifyBelowThreshold = didNotifyBelowThreshold
-        self.sessionKeyExpiration = sessionKeyExpiration
     }
 }
 

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -122,14 +122,6 @@ class UsageService: NSObject, ObservableObject {
             return
         }
 
-        if let expiration = account.sessionKeyExpiration, expiration < Date() {
-            consecutiveFailures += 1
-            authFailed = true
-            logger.info("Session cookie expired, triggering re-auth")
-            onAuthFailure?()
-            return
-        }
-
         guard let request = ClaudeAPI.makeRequest(path: "/api/organizations/\(account.organizationId)/usage", sessionKey: account.sessionKey) else {
             consecutiveFailures += 1
             logger.error("Failed to construct usage API URL")


### PR DESCRIPTION
## Summary

- **Multi-org users see wrong usage (100%/100%)**: App now shows an org picker when multiple orgs are detected, instead of blindly selecting `orgs[0]`. Re-auth auto-selects the active account's org when it's still in the list.
- **Google OAuth "error logging you in"**: Replaced `applicationNameForUserAgent` (appends to UA) with `customUserAgent` (full replacement), making the WKWebView indistinguishable from Safari.
- **Email/code login immediately shows "Session expired"**: Stopped trusting `cookie.expiresDate` from non-persistent WKWebView store. Removed the pre-flight expiration check entirely. Added migration to clear stale expirations from existing accounts on launch.

## Changes

| File | Change |
|------|--------|
| `AuthManager.swift` | Org picker via NSAlert + NSPopUpButton, re-auth auto-select, enriched Organization model (name, billingType, emailAddress, displayName), `pendingExpiration = nil` on HTTP cookie capture, `customUserAgent` replaces `applicationNameForUserAgent` |
| `UsageService.swift` | Removed pre-flight `sessionKeyExpiration` check (dead code after migration) |
| `AccountStore.swift` | Added `clearSessionExpirations()` migration helper |
| `ClaudeBatteryApp.swift` | Call migration on launch before polling starts |
| `ClaudeAPI.swift` | Removed unused `safariUserAgentSuffix` |

## Test plan

- [ ] Fresh sign-in with email/code: no "Session expired" after login
- [ ] Fresh sign-in with Google OAuth: no "error logging you in"
- [ ] Multi-org user: org picker appears, selected org's usage is shown
- [ ] Single-org user: no picker, no behavior change
- [ ] Re-auth with same org: auto-selects, no picker
- [ ] Cancel org picker: state resets cleanly, can retry
- [ ] Existing v1.44 user upgrades: stale sessionKeyExpiration cleared, no false "Session expired"
- [ ] Quit and relaunch: polling resumes, API determines session validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)