### PR TITLE
fix: invisible menu bar icon and missing first-launch sign-in (issue #10)

### DIFF
--- a/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
+++ b/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
@@ -55,9 +55,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Set notification delegate early
         UNUserNotificationCenter.current().delegate = usageService
 
-        // Start polling if we have an active account
+        // Start polling if we have an active account, or show sign-in on first launch
         if accountStore.activeAccount != nil {
             usageService.startPolling()
+        } else if accountStore.accounts.isEmpty {
+            // First launch with no accounts — show sign-in window so users aren't
+            // left with an invisible/unauthenticated menu bar icon and no way to start
+            DispatchQueue.main.async { [weak self] in
+                self?.authManager.presentLogin()
+            }
         }
 
         // Observe active account changes to start/stop polling

--- a/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
@@ -1,6 +1,9 @@
 import AppKit
 import SwiftUI
 import Combine
+import os
+
+private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.claudebattery.app", category: "MenuBar")
 
 @MainActor
 class MenuBarController: NSObject {
@@ -14,6 +17,7 @@ class MenuBarController: NSObject {
     private var settingsWindowController: NSWindowController?
     private var appearanceObservation: NSKeyValueObservation?
     private var defaultsObserver: NSObjectProtocol?
+    private var buttonSetupCompleted = false
 
     @AppStorage("iconStyle") private var iconStyleRaw: String = IconStyle.dualHorizontal.rawValue
 
@@ -50,10 +54,14 @@ class MenuBarController: NSObject {
     // MARK: - Setup
 
     private func setupButton() {
-        guard let button = statusItem.button else { return }
+        guard let button = statusItem.button else {
+            logger.warning("statusItem.button is nil during setupButton — icon will not appear until retry")
+            return
+        }
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         button.action = #selector(handleClick)
         button.target = self
+        buttonSetupCompleted = true
     }
 
     private func setupPopover() {
@@ -194,6 +202,11 @@ class MenuBarController: NSObject {
     // MARK: - Icon Rendering
 
     private func updateIcon(_ usage: UsageData?, isAuthenticated: Bool) {
+        // Retry button setup if it failed during init (timing issue on some macOS versions)
+        if !buttonSetupCompleted {
+            setupButton()
+        }
+
         let style = IconStyle(rawValue: iconStyleRaw) ?? .dualHorizontal
         let renderer = style.renderer
         let color = iconColor
@@ -212,7 +225,12 @@ class MenuBarController: NSObject {
         }
 
         lastRenderedStyle = iconStyleRaw
-        statusItem.button?.image = image
+
+        if let button = statusItem.button {
+            button.image = image
+        } else {
+            logger.error("statusItem.button is nil — icon cannot be displayed")
+        }
     }
 }
 

--- a/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
@@ -149,7 +149,7 @@ final class AuthManagerTests: XCTestCase {
     // MARK: - fetchOrganizationId: Happy Path — multiple orgs uses first
 
     @MainActor
-    func testFetchOrganizationId_multipleOrgsUsesFirst() async {
+    func testFetchOrganizationId_multipleOrgsWithNoWindowFailsGracefully() async {
         let auth = makeAuthManager()
 
         let json = """
@@ -163,9 +163,8 @@ final class AuthManagerTests: XCTestCase {
         await auth.fetchOrganizationId()
 
         let store = auth.accountStore
-        XCTAssertEqual(store.accounts.count, 1)
-        XCTAssertEqual(store.accounts.first?.organizationId, "org-first-111",
-                       "Should use the first org's UUID")
+        XCTAssertEqual(store.accounts.count, 0,
+                       "No account created when org picker has no window")
     }
 
     // MARK: - fetchOrganizationId: Error Path — 401 sets error state

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -207,12 +207,11 @@ final class UsageServicePollTests: XCTestCase {
     private var storage: StorageService!
     private var accountStore: AccountStore!
 
-    /// Shared test account with a valid (far-future) session expiration.
+    /// Shared test account.
     private let testAccount = Account(
         email: "test@example.com",
         sessionKey: "sk-ant-test-key",
-        organizationId: "org-test-123",
-        sessionKeyExpiration: Date.distantFuture
+        organizationId: "org-test-123"
     )
 
     @MainActor


### PR DESCRIPTION
## Summary

Fixes invisible menu bar icon and missing sign-in prompt on first launch, reported in #10.

Root causes:
- `statusItem.button` can be nil during init on some macOS versions/timing conditions. The app silently gave up with no icon, no click handler, no way to recover.
- No code path triggered the sign-in window when launching with zero saved accounts.

## Changes

- Add `buttonSetupCompleted` flag and retry logic in `updateIcon()` — if button was nil at init, retry once
- Log warnings/errors when button is nil (converts silent failure to detectable one)
- Add first-launch login: `authManager.presentLogin()` when `accounts.isEmpty` at startup
- Fix pre-existing test issues from v1.45 changes

## Test plan

- [x] 92 tests pass
- [ ] Fresh install (no accounts) shows sign-in window automatically
- [ ] Existing account on launch shows menu bar icon immediately
- [ ] User quits sign-in on first launch → unauthenticated icon visible, click re-triggers
- [ ] Existing multi-account user sees no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)