### PR TITLE
fix: harden cookie capture with dashboard URL detection (issue #7)

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -88,10 +88,9 @@ class AuthManager: NSObject, ObservableObject {
                 // Trigger an aggressive delayed cookie check to catch the session
                 // cookie that may not yet be in the store.
                 if let url = webView.url,
-                   url.scheme == "https",
-                   url.host == "claude.ai",
-                   let path = url.path.isEmpty ? nil : url.path,
-                   path.hasPrefix("/chat") || path.hasPrefix("/new") || path == "/" {
+                   Self.isDashboardURL(url) {
+                    let path = url.path
+                    _ = path // used in debug log below
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
                         guard let self, !self.hasCapturedSession, let webView = self.loginWebView else { return }
                         #if DEBUG
@@ -188,6 +187,16 @@ class AuthManager: NSObject, ObservableObject {
     static func isSessionCookie(_ cookie: HTTPCookie) -> Bool {
         cookie.name == "sessionKey" &&
         (cookie.domain == "claude.ai" || cookie.domain == ".claude.ai")
+    }
+
+    /// Returns true when the URL is a claude.ai dashboard path, indicating the user
+    /// likely completed login via SPA navigation. Used to trigger aggressive cookie re-checks.
+    // internal for @testable access in AuthManagerTests
+    nonisolated static func isDashboardURL(_ url: URL) -> Bool {
+        guard url.scheme == "https", url.host == "claude.ai" else { return false }
+        let path = url.path
+        guard !path.isEmpty else { return false }
+        return path.hasPrefix("/chat") || path.hasPrefix("/new") || path == "/"
     }
 
     // internal for @testable access in AuthManagerTests

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -82,6 +82,24 @@ class AuthManager: NSObject, ObservableObject {
             Task { @MainActor [weak self] in
                 guard let self, !self.hasCapturedSession else { return }
                 self.checkCookiesFromAllSources(webView)
+
+                // URL-based dashboard detection: if the WebView navigated to a
+                // claude.ai dashboard path, the user likely completed login via SPA.
+                // Trigger an aggressive delayed cookie check to catch the session
+                // cookie that may not yet be in the store.
+                if let url = webView.url,
+                   url.scheme == "https",
+                   url.host == "claude.ai",
+                   let path = url.path.isEmpty ? nil : url.path,
+                   path.hasPrefix("/chat") || path.hasPrefix("/new") || path == "/" {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                        guard let self, !self.hasCapturedSession, let webView = self.loginWebView else { return }
+                        #if DEBUG
+                        logger.debug("Dashboard URL detected (\(path)) — aggressive cookie re-check")
+                        #endif
+                        self.checkCookiesFromAllSources(webView)
+                    }
+                }
             }
         }
 
@@ -89,6 +107,9 @@ class AuthManager: NSObject, ObservableObject {
         cookiePollTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self, !self.hasCapturedSession, let webView = self.loginWebView else { return }
+                #if DEBUG
+                logger.debug("Cookie poll timer fired — URL: \(webView.url?.absoluteString ?? "nil")")
+                #endif
                 self.checkCookiesFromAllSources(webView)
             }
         }

--- a/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
@@ -146,7 +146,7 @@ final class AuthManagerTests: XCTestCase {
         XCTAssertEqual(auth.loginState, .idle, "Should return to idle after success")
     }
 
-    // MARK: - fetchOrganizationId: Happy Path — multiple orgs uses first
+    // MARK: - fetchOrganizationId: Edge Case — multiple orgs with no window fails gracefully
 
     @MainActor
     func testFetchOrganizationId_multipleOrgsWithNoWindowFailsGracefully() async {
@@ -302,6 +302,48 @@ final class AuthManagerTests: XCTestCase {
         XCTAssertEqual(store.accounts.first?.sessionKey, "sk-refreshed-key",
                        "Session key should be updated on re-auth")
         XCTAssertEqual(auth.loginState, .idle)
+    }
+
+    // MARK: - isDashboardURL
+
+    func testIsDashboardURL_chatPath() {
+        let url = URL(string: "https://claude.ai/chat")!
+        XCTAssertTrue(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_chatSubpath() {
+        let url = URL(string: "https://claude.ai/chat/abc-123")!
+        XCTAssertTrue(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_newPath() {
+        let url = URL(string: "https://claude.ai/new")!
+        XCTAssertTrue(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_rootPath() {
+        let url = URL(string: "https://claude.ai/")!
+        XCTAssertTrue(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_nonDashboardPath() {
+        let url = URL(string: "https://claude.ai/api/organizations")!
+        XCTAssertFalse(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_loginPath() {
+        let url = URL(string: "https://claude.ai/login")!
+        XCTAssertFalse(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_wrongHost() {
+        let url = URL(string: "https://other.com/chat")!
+        XCTAssertFalse(AuthManager.isDashboardURL(url))
+    }
+
+    func testIsDashboardURL_httpScheme() {
+        let url = URL(string: "http://claude.ai/chat")!
+        XCTAssertFalse(AuthManager.isDashboardURL(url))
     }
 
     // MARK: - LoginState equality


### PR DESCRIPTION
Fixes cookie capture for email/code login. Adds URL-based dashboard detection with domain validation plus diagnostic logging. Relates to #7. 🤖 Generated with Claude Code