### PR TITLE
feat: cookie-based auth, OAuth popups, prepaid balance display

### DIFF
--- a/ClaudeBattery/ClaudeBattery.xcodeproj/project.pbxproj
+++ b/ClaudeBattery/ClaudeBattery.xcodeproj/project.pbxproj
@@ -3,13 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 100;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		09C1A92B095161678D2A3778 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1188B7AAC9F9C765EEF70301 /* Cocoa.framework */; };
-		522F8A60215EA3D91D88C782 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A9D8FEA3510DE3A69EEA9F /* UpdateCheckerTests.swift */; };
-		6BD92493B6E2F2C928493ED9 /* ClaudeAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882ED57CBE7110FF7B5A110A /* ClaudeAPITests.swift */; };
 		A1000000000000000000000A /* ClaudeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000C /* ClaudeAPI.swift */; };
 		A1000000000000000000000B /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000D /* UpdateChecker.swift */; };
 		A10000010000000000000001 /* ClaudeBatteryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000001 /* ClaudeBatteryApp.swift */; };
@@ -28,41 +25,9 @@
 		B10000050000000000000005 /* DualArcGaugeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20000050000000000000005 /* DualArcGaugeRenderer.swift */; };
 		B10000060000000000000006 /* TextOnlyRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20000060000000000000006 /* TextOnlyRenderer.swift */; };
 		B10000070000000000000007 /* StackedBarsRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20000070000000000000007 /* StackedBarsRenderer.swift */; };
-		B8B7E94DFB5BF777D586E1F6 /* IconStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55346AC851D0669ADFB2113D /* IconStyleTests.swift */; };
-		C10000010000000000000001 /* StorageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000010000000000000001 /* StorageServiceTests.swift */; };
-		C10000020000000000000002 /* AccountStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000020000000000000002 /* AccountStoreTests.swift */; };
-		C10000030000000000000003 /* UsageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000030000000000000003 /* UsageServiceTests.swift */; };
-		C10000040000000000000004 /* MockHTTPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000040000000000000004 /* MockHTTPSession.swift */; };
-		C10000050000000000000005 /* usage_full.json in Resources */ = {isa = PBXBuildFile; fileRef = C20000050000000000000005 /* usage_full.json */; };
-		C10000060000000000000006 /* usage_nil_fields.json in Resources */ = {isa = PBXBuildFile; fileRef = C20000060000000000000006 /* usage_nil_fields.json */; };
-		C10000070000000000000007 /* usage_extra_usage.json in Resources */ = {isa = PBXBuildFile; fileRef = C20000070000000000000007 /* usage_extra_usage.json */; };
-		D10000010000000000000001 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20000010000000000000001 /* AuthManagerTests.swift */; };
-		D10000020000000000000002 /* OrganizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20000020000000000000002 /* OrganizationTests.swift */; };
-		D10000030000000000000003 /* orgs_single.json in Resources */ = {isa = PBXBuildFile; fileRef = D20000030000000000000003 /* orgs_single.json */; };
-		D10000040000000000000004 /* orgs_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = D20000040000000000000004 /* orgs_multiple.json */; };
-		D10000050000000000000005 /* orgs_empty.json in Resources */ = {isa = PBXBuildFile; fileRef = D20000050000000000000005 /* orgs_empty.json */; };
-		D9349C6F15CD2C504DCC2896 /* github_release.json in Resources */ = {isa = PBXBuildFile; fileRef = 1232516F2B36B5410E84AEF4 /* github_release.json */; };
-		E60B83499A3692A0D57124E8 /* HTTPDataFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FA3E7941EBB6529BB0D867 /* HTTPDataFetching.swift */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		DB3233E6EEA81A2B6C751314 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A80000010000000000000001 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A50000010000000000000001;
-			remoteInfo = ClaudeBattery;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
-		06A9D8FEA3510DE3A69EEA9F /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
-		1188B7AAC9F9C765EEF70301 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		1232516F2B36B5410E84AEF4 /* github_release.json */ = {isa = PBXFileReference; includeInIndex = 1; path = github_release.json; sourceTree = "<group>"; };
-		40FA3E7941EBB6529BB0D867 /* HTTPDataFetching.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPDataFetching.swift; sourceTree = "<group>"; };
-		55346AC851D0669ADFB2113D /* IconStyleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IconStyleTests.swift; sourceTree = "<group>"; };
-		882ED57CBE7110FF7B5A110A /* ClaudeAPITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClaudeAPITests.swift; sourceTree = "<group>"; };
-		9122EF168B95FED765D28F78 /* ClaudeBatteryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ClaudeBatteryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2000000000000000000000A /* ClaudeBattery.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ClaudeBattery.entitlements; sourceTree = "<group>"; };
 		A2000000000000000000000B /* ClaudeBattery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClaudeBattery.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2000000000000000000000C /* ClaudeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAPI.swift; sourceTree = "<group>"; };
@@ -84,86 +49,22 @@
 		B20000050000000000000005 /* DualArcGaugeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualArcGaugeRenderer.swift; sourceTree = "<group>"; };
 		B20000060000000000000006 /* TextOnlyRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextOnlyRenderer.swift; sourceTree = "<group>"; };
 		B20000070000000000000007 /* StackedBarsRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedBarsRenderer.swift; sourceTree = "<group>"; };
-		C20000010000000000000001 /* StorageServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StorageServiceTests.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
-		C20000020000000000000002 /* AccountStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccountStoreTests.swift; path = AccountStoreTests.swift; sourceTree = "<group>"; };
-		C20000030000000000000003 /* UsageServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UsageServiceTests.swift; path = UsageServiceTests.swift; sourceTree = "<group>"; };
-		C20000040000000000000004 /* MockHTTPSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockHTTPSession.swift; path = Helpers/MockHTTPSession.swift; sourceTree = "<group>"; };
-		C20000050000000000000005 /* usage_full.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = usage_full.json; path = Fixtures/usage_full.json; sourceTree = "<group>"; };
-		C20000060000000000000006 /* usage_nil_fields.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = usage_nil_fields.json; path = Fixtures/usage_nil_fields.json; sourceTree = "<group>"; };
-		C20000070000000000000007 /* usage_extra_usage.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = usage_extra_usage.json; path = Fixtures/usage_extra_usage.json; sourceTree = "<group>"; };
-		D20000010000000000000001 /* AuthManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthManagerTests.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
-		D20000020000000000000002 /* OrganizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OrganizationTests.swift; path = OrganizationTests.swift; sourceTree = "<group>"; };
-		D20000030000000000000003 /* orgs_single.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = orgs_single.json; path = Fixtures/orgs_single.json; sourceTree = "<group>"; };
-		D20000040000000000000004 /* orgs_multiple.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = orgs_multiple.json; path = Fixtures/orgs_multiple.json; sourceTree = "<group>"; };
-		D20000050000000000000005 /* orgs_empty.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = orgs_empty.json; path = Fixtures/orgs_empty.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A30000010000000000000001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C9D194409AA64A3A99FE8C09 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				09C1A92B095161678D2A3778 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		25063B05958C2C313EF4539C /* OS X */ = {
-			isa = PBXGroup;
-			children = (
-				1188B7AAC9F9C765EEF70301 /* Cocoa.framework */,
-			);
-			name = "OS X";
-			sourceTree = "<group>";
-		};
-		2D74A40D83CBBEDA6C45DC8F /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				25063B05958C2C313EF4539C /* OS X */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		7C62D77671ACD7827B66F6A3 /* ClaudeBatteryTests */ = {
-			isa = PBXGroup;
-			children = (
-				C20000010000000000000001 /* StorageServiceTests.swift */,
-				C20000020000000000000002 /* AccountStoreTests.swift */,
-				C20000030000000000000003 /* UsageServiceTests.swift */,
-				C20000040000000000000004 /* MockHTTPSession.swift */,
-				C20000050000000000000005 /* usage_full.json */,
-				C20000060000000000000006 /* usage_nil_fields.json */,
-				C20000070000000000000007 /* usage_extra_usage.json */,
-				D20000010000000000000001 /* AuthManagerTests.swift */,
-				D20000020000000000000002 /* OrganizationTests.swift */,
-				D20000030000000000000003 /* orgs_single.json */,
-				D20000040000000000000004 /* orgs_multiple.json */,
-				D20000050000000000000005 /* orgs_empty.json */,
-				C47FA80A990791E4034FD1BC /* Fixtures */,
-				882ED57CBE7110FF7B5A110A /* ClaudeAPITests.swift */,
-				06A9D8FEA3510DE3A69EEA9F /* UpdateCheckerTests.swift */,
-				55346AC851D0669ADFB2113D /* IconStyleTests.swift */,
-			);
-			name = ClaudeBatteryTests;
-			path = ClaudeBatteryTests;
-			sourceTree = "<group>";
-		};
 		A40000010000000000000001 = {
 			isa = PBXGroup;
 			children = (
 				A40000020000000000000002 /* ClaudeBattery */,
 				A40000060000000000000006 /* Products */,
-				2D74A40D83CBBEDA6C45DC8F /* Frameworks */,
-				7C62D77671ACD7827B66F6A3 /* ClaudeBatteryTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -196,7 +97,6 @@
 				A20000090000000000000010 /* AccountStore.swift */,
 				A2000000000000000000000C /* ClaudeAPI.swift */,
 				A2000000000000000000000D /* UpdateChecker.swift */,
-				40FA3E7941EBB6529BB0D867 /* HTTPDataFetching.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -216,7 +116,6 @@
 			isa = PBXGroup;
 			children = (
 				A2000000000000000000000B /* ClaudeBattery.app */,
-				9122EF168B95FED765D28F78 /* ClaudeBatteryTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -252,36 +151,9 @@
 			path = IconRendering;
 			sourceTree = "<group>";
 		};
-		C47FA80A990791E4034FD1BC /* Fixtures */ = {
-			isa = PBXGroup;
-			children = (
-				1232516F2B36B5410E84AEF4 /* github_release.json */,
-			);
-			name = Fixtures;
-			path = Fixtures;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		0EFBC817EC5BA68402D7EB6B /* ClaudeBatteryTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = EC4B9E222C00870F4780A378 /* Build configuration list for PBXNativeTarget "ClaudeBatteryTests" */;
-			buildPhases = (
-				F554355C76DD2168063F8A21 /* Sources */,
-				C9D194409AA64A3A99FE8C09 /* Frameworks */,
-				185A5F1F4DF0DB18C0D63D76 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				3901F6BD976B998DBE21204C /* PBXTargetDependency */,
-			);
-			name = ClaudeBatteryTests;
-			productName = ClaudeBatteryTests;
-			productReference = 9122EF168B95FED765D28F78 /* ClaudeBatteryTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		A50000010000000000000001 /* ClaudeBattery */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A70000010000000000000001 /* Build configuration list for PBXNativeTarget "ClaudeBattery" */;
@@ -291,8 +163,6 @@
 				A60000020000000000000002 /* Resources */,
 			);
 			buildRules = (
-			);
-			dependencies = (
 			);
 			name = ClaudeBattery;
 			productName = ClaudeBattery;
@@ -307,7 +177,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1520;
-				LastUpgradeCheck = 2620;
+				LastUpgradeCheck = 2640;
 				TargetAttributes = {
 					A50000010000000000000001 = {
 						CreatedOnToolsVersion = 15.2;
@@ -315,7 +185,6 @@
 				};
 			};
 			buildConfigurationList = A70000020000000000000002 /* Build configuration list for PBXProject "ClaudeBattery" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -323,45 +192,28 @@
 				Base,
 			);
 			mainGroup = A40000010000000000000001;
+			preferredProjectObjectVersion = 100;
 			productRefGroup = A40000060000000000000006 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				A50000010000000000000001 /* ClaudeBattery */,
-				0EFBC817EC5BA68402D7EB6B /* ClaudeBatteryTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		185A5F1F4DF0DB18C0D63D76 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C10000050000000000000005 /* usage_full.json in Resources */,
-				C10000060000000000000006 /* usage_nil_fields.json in Resources */,
-				C10000070000000000000007 /* usage_extra_usage.json in Resources */,
-				D10000030000000000000003 /* orgs_single.json in Resources */,
-				D10000040000000000000004 /* orgs_multiple.json in Resources */,
-				D10000050000000000000005 /* orgs_empty.json in Resources */,
-				D9349C6F15CD2C504DCC2896 /* github_release.json in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		A60000020000000000000002 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				A10000080000000000000008 /* Assets.xcassets in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A60000010000000000000001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				A10000010000000000000001 /* ClaudeBatteryApp.swift in Sources */,
 				A10000020000000000000002 /* StorageService.swift in Sources */,
@@ -380,75 +232,12 @@
 				B10000050000000000000005 /* DualArcGaugeRenderer.swift in Sources */,
 				B10000060000000000000006 /* TextOnlyRenderer.swift in Sources */,
 				B10000070000000000000007 /* StackedBarsRenderer.swift in Sources */,
-				E60B83499A3692A0D57124E8 /* HTTPDataFetching.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F554355C76DD2168063F8A21 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C10000010000000000000001 /* StorageServiceTests.swift in Sources */,
-				C10000020000000000000002 /* AccountStoreTests.swift in Sources */,
-				C10000030000000000000003 /* UsageServiceTests.swift in Sources */,
-				C10000040000000000000004 /* MockHTTPSession.swift in Sources */,
-				D10000010000000000000001 /* AuthManagerTests.swift in Sources */,
-				D10000020000000000000002 /* OrganizationTests.swift in Sources */,
-				6BD92493B6E2F2C928493ED9 /* ClaudeAPITests.swift in Sources */,
-				522F8A60215EA3D91D88C782 /* UpdateCheckerTests.swift in Sources */,
-				B8B7E94DFB5BF777D586E1F6 /* IconStyleTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		3901F6BD976B998DBE21204C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ClaudeBattery;
-			target = A50000010000000000000001 /* ClaudeBattery */;
-			targetProxy = DB3233E6EEA81A2B6C751314 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin XCBuildConfiguration section */
-		460B6C3D88FB72DEDAFB6038 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PJHS9XQS6H;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "";
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.reebz.claudebattery.tests;
-				PRODUCT_MODULE_NAME = ClaudeBatteryTests;
-				PRODUCT_NAME = ClaudeBatteryTests;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ClaudeBattery.app/Contents/MacOS/ClaudeBattery";
-			};
-			name = Release;
-		};
-		83165F23BCFBBEAF6E076FD5 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PJHS9XQS6H;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = "";
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.reebz.claudebattery.tests;
-				PRODUCT_MODULE_NAME = ClaudeBatteryTests;
-				PRODUCT_NAME = ClaudeBatteryTests;
-				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ClaudeBattery.app/Contents/MacOS/ClaudeBattery";
-			};
-			name = Debug;
-		};
-		A90000010000000000000001 /* Debug */ = {
+		A90000010000000000000001 /* Debug configuration for PBXProject "ClaudeBattery" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -513,7 +302,7 @@
 			};
 			name = Debug;
 		};
-		A90000020000000000000002 /* Release */ = {
+		A90000020000000000000002 /* Release configuration for PBXProject "ClaudeBattery" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -570,7 +359,7 @@
 			};
 			name = Release;
 		};
-		A90000030000000000000003 /* Debug */ = {
+		A90000030000000000000003 /* Debug configuration for PBXNativeTarget "ClaudeBattery" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -581,9 +370,9 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PJHS9XQS6H;
+				DEVELOPMENT_TEAM = C28U2CQDLX;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -597,8 +386,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.45;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.44;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reebz.claudebattery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -608,20 +397,21 @@
 			};
 			name = Debug;
 		};
-		A90000040000000000000004 /* Release */ = {
+		A90000040000000000000004 /* Release configuration for PBXNativeTarget "ClaudeBattery" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = ClaudeBattery/Resources/ClaudeBattery.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = PJHS9XQS6H;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = C28U2CQDLX;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -635,8 +425,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
-				MARKETING_VERSION = 1.45;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.44;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reebz.claudebattery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -652,28 +442,17 @@
 		A70000010000000000000001 /* Build configuration list for PBXNativeTarget "ClaudeBattery" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A90000030000000000000003 /* Debug */,
-				A90000040000000000000004 /* Release */,
+				A90000030000000000000003 /* Debug configuration for PBXNativeTarget "ClaudeBattery" */,
+				A90000040000000000000004 /* Release configuration for PBXNativeTarget "ClaudeBattery" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		A70000020000000000000002 /* Build configuration list for PBXProject "ClaudeBattery" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A90000010000000000000001 /* Debug */,
-				A90000020000000000000002 /* Release */,
+				A90000010000000000000001 /* Debug configuration for PBXProject "ClaudeBattery" */,
+				A90000020000000000000002 /* Release configuration for PBXProject "ClaudeBattery" */,
 			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		EC4B9E222C00870F4780A378 /* Build configuration list for PBXNativeTarget "ClaudeBatteryTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				460B6C3D88FB72DEDAFB6038 /* Release */,
-				83165F23BCFBBEAF6E076FD5 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/ClaudeBattery/ClaudeBattery.xcodeproj/xcshareddata/xcschemes/ClaudeBattery.xcscheme
+++ b/ClaudeBattery/ClaudeBattery.xcodeproj/xcshareddata/xcschemes/ClaudeBattery.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2620"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,18 +29,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0EFBC817EC5BA68402D7EB6B"
-               BuildableName = "ClaudeBatteryTests.xctest"
-               BlueprintName = "ClaudeBatteryTests"
-               ReferencedContainer = "container:ClaudeBattery.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"

--- a/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
@@ -83,9 +83,11 @@ class AccountStore: ObservableObject {
         logger.info("Switched to account \(id.uuidString)")
     }
 
-    func updateSessionKey(_ id: UUID, _ sessionKey: String) {
+    func updateSessionKey(_ id: UUID, _ sessionKey: String, expiration: Date? = nil, cookieHeader: String? = nil) {
         guard let index = accounts.firstIndex(where: { $0.id == id }) else { return }
         accounts[index].sessionKey = sessionKey
+        accounts[index].sessionKeyExpiration = expiration
+        accounts[index].allCookieHeader = cookieHeader
         persist()
     }
 

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -16,9 +16,7 @@ class AuthManager: NSObject, ObservableObject {
     @Published var loginState: LoginState = .idle
 
     private let storage: StorageService
-    // internal for @testable access in AuthManagerTests
-    let accountStore: AccountStore
-    private let session: any HTTPDataFetching
+    private let accountStore: AccountStore
     private var loginWebView: WKWebView?
     private var loginWindowController: NSWindowController?
     private var loginTimeoutTask: Task<Void, Never>?
@@ -26,13 +24,14 @@ class AuthManager: NSObject, ObservableObject {
     private var cookiePollTimer: Timer?
     private var urlObservation: NSKeyValueObservation?
     private var hasCapturedSession = false
-    // internal for @testable access in AuthManagerTests
-    var pendingSessionKey: String?
+    private var pendingSessionKey: String?
+    private var pendingExpiration: Date?
+    private var pendingCookieHeader: String?
+    private var popupWebView: WKWebView?
 
-    init(storage: StorageService, accountStore: AccountStore, session: any HTTPDataFetching = ClaudeAPI.session) {
+    init(storage: StorageService, accountStore: AccountStore) {
         self.storage = storage
         self.accountStore = accountStore
-        self.session = session
         super.init()
     }
 
@@ -51,10 +50,11 @@ class AuthManager: NSObject, ObservableObject {
 
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
+        config.applicationNameForUserAgent = ClaudeAPI.safariUserAgentSuffix
 
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 640), configuration: config)
-        webView.customUserAgent = ClaudeAPI.safariUserAgent
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         self.loginWebView = webView
 
         config.websiteDataStore.httpCookieStore.add(self)
@@ -138,6 +138,8 @@ class AuthManager: NSObject, ObservableObject {
                     logger.info("Session cookie captured via JavaScript fallback")
                     self.hasCapturedSession = true
                     self.pendingSessionKey = value
+                    self.pendingExpiration = nil  // JS cookies don't expose expiration
+                    self.pendingCookieHeader = cookieString  // Full JS cookie string includes all visible cookies
                     self.loginState = .signingIn
                     self.cookiePollTimer?.invalidate()
                     self.cookiePollTimer = nil
@@ -156,6 +158,8 @@ class AuthManager: NSObject, ObservableObject {
         cookiePollTimer = nil
         urlObservation?.invalidate()
         urlObservation = nil
+        popupWebView?.removeFromSuperview()
+        popupWebView = nil
         loginWebView?.stopLoading()
         loginWebView?.configuration.websiteDataStore.httpCookieStore.remove(self)
         loginWebView = nil
@@ -163,45 +167,56 @@ class AuthManager: NSObject, ObservableObject {
         loginWindowController = nil
     }
 
-    // internal for @testable access in AuthManagerTests
-    static func isSessionCookie(_ cookie: HTTPCookie) -> Bool {
+    private static func isSessionCookie(_ cookie: HTTPCookie) -> Bool {
         cookie.name == "sessionKey" &&
-        (cookie.domain == "claude.ai" || cookie.domain == ".claude.ai")
+        (cookie.domain == "claude.ai" || cookie.domain == ".claude.ai" || cookie.domain.hasSuffix(".claude.ai"))
     }
 
-    // internal for @testable access in AuthManagerTests
-    func handleCookieCaptured(_ cookie: HTTPCookie) {
+    private func handleCookieCaptured(_ cookie: HTTPCookie) {
         guard !hasCapturedSession else { return }
 
         guard Self.isSessionCookie(cookie),
               cookie.isSecure,
               cookie.path == "/" else {
-            logger.debug("Cookie rejected — name=\(cookie.name) domain=\(cookie.domain)")
+            logger.debug("Cookie rejected — name=\(cookie.name) domain=\(cookie.domain) path=\(cookie.path)")
             return
         }
 
         hasCapturedSession = true
         pendingSessionKey = cookie.value
+        pendingExpiration = cookie.expiresDate
         loginState = .signingIn
         cookiePollTimer?.invalidate()
         cookiePollTimer = nil
 
         logger.info("Session cookie captured via cookie store")
 
-        orgDiscoveryTask = Task { await fetchOrganizationId() }
+        // Capture ALL cookies from the WebView to include in API requests
+        // (Cloudflare, CSRF tokens, etc. may be required alongside sessionKey)
+        Task {
+            guard let webView = loginWebView else {
+                orgDiscoveryTask = Task { await fetchOrganizationId() }
+                return
+            }
+            let allCookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
+            let claudeCookies = allCookies.filter { $0.domain == "claude.ai" || $0.domain == ".claude.ai" || $0.domain.hasSuffix(".claude.ai") }
+            let header = claudeCookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+            pendingCookieHeader = header.isEmpty ? nil : header
+            logger.info("Captured \(claudeCookies.count) cookies for API requests")
+            orgDiscoveryTask = Task { await fetchOrganizationId() }
+        }
     }
 
     // MARK: - Org Discovery
 
-    // internal for @testable access in AuthManagerTests
-    func fetchOrganizationId() async {
+    private func fetchOrganizationId() async {
         guard let sessionKey = pendingSessionKey else {
             loginState = .idle
             stopLoginWindow()
             return
         }
 
-        guard let request = ClaudeAPI.makeRequest(path: "/api/organizations", sessionKey: sessionKey) else {
+        guard let request = ClaudeAPI.makeRequest(path: "/api/organizations", sessionKey: sessionKey, cookieHeader: pendingCookieHeader) else {
             logger.error("Failed to construct organizations API URL")
             handleOrgDiscoveryFailure("Connection error. Please try again.")
             showLoginAlert("Connection Error", "Could not complete sign-in. Please close this window and try again.")
@@ -209,7 +224,7 @@ class AuthManager: NSObject, ObservableObject {
         }
 
         do {
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await ClaudeAPI.session.data(for: request)
 
             guard !Task.isCancelled else { return }
 
@@ -248,53 +263,77 @@ class AuthManager: NSObject, ObservableObject {
                 return
             }
 
-            // Determine which org to use
-            let chosenOrg: Organization
-            if orgs.count == 1 {
-                chosenOrg = orgs[0]
-            } else if let existingAccount = accountStore.accounts.first(where: { acct in orgs.contains(where: { $0.uuid == acct.organizationId }) }),
-                      let match = orgs.first(where: { $0.uuid == existingAccount.organizationId }) {
-                // Re-auth: auto-select if any existing account's org is in the list
-                chosenOrg = match
-                logger.info("Re-auth auto-selected org for account \(existingAccount.displayName): \(match.displayName)")
-            } else {
-                // Multiple orgs, no auto-select match — show picker
-                guard let picked = await showOrgPicker(orgs: orgs) else {
-                    // User cancelled the picker
-                    handleOrgDiscoveryFailure("Sign-in cancelled.")
-                    return
+            logger.info("Found \(orgs.count) organization(s): \(orgs.map(\.uuid).joined(separator: ", "))")
+
+            // Probe each org's usage endpoint to find one that grants access.
+            // The first org isn't always the one with a Pro/Max subscription.
+            let cookieHeader = pendingCookieHeader
+            var validOrgUUID: String?
+            for org in orgs {
+                guard !Task.isCancelled else { return }
+                if let probe = ClaudeAPI.makeRequest(path: "/api/organizations/\(org.uuid)/usage", sessionKey: sessionKey, cookieHeader: cookieHeader) {
+                    do {
+                        let (_, probeResp) = try await ClaudeAPI.session.data(for: probe)
+                        if let httpProbe = probeResp as? HTTPURLResponse {
+                            logger.info("Usage probe for org \(org.uuid): HTTP \(httpProbe.statusCode)")
+                            if (200...299).contains(httpProbe.statusCode) {
+                                validOrgUUID = org.uuid
+                                break
+                            }
+                        }
+                    } catch {
+                        logger.warning("Usage probe failed for org \(org.uuid): \(error.localizedDescription)")
+                    }
                 }
-                chosenOrg = picked
             }
 
-            guard !Task.isCancelled else { return }
+            guard let orgUUID = validOrgUUID else {
+                logger.warning("No organization with usage access found")
+                handleOrgDiscoveryFailure("No organization with usage access.")
+                showLoginAlert("No Usage Access", "None of the \(orgs.count) organization(s) on this account have usage data access. A Pro or Max subscription may be required.")
+                return
+            }
 
             // Try to extract email from org response
-            let email = extractEmail(from: orgs, rawData: data) ?? "Account \(accountStore.accounts.count + 1)"
+            let email = extractEmail(from: data) ?? "Account \(accountStore.accounts.count + 1)"
 
             let account = Account(
                 email: email,
                 sessionKey: sessionKey,
-                organizationId: chosenOrg.uuid
+                organizationId: orgUUID,
+                sessionKeyExpiration: pendingExpiration,
+                allCookieHeader: cookieHeader
             )
 
             if accountStore.addAccount(account) {
                 accountStore.switchTo(account.id)
                 logger.info("Account added and activated: \(account.displayName)")
-            } else if let existing = accountStore.accounts.first(where: { $0.organizationId == chosenOrg.uuid }) {
+            } else if let existing = accountStore.accounts.first(where: { $0.organizationId == orgUUID }) {
                 // Re-authentication: update session key on existing account
-                accountStore.updateSessionKey(existing.id, sessionKey)
+                accountStore.updateSessionKey(existing.id, sessionKey, expiration: pendingExpiration, cookieHeader: cookieHeader)
                 accountStore.switchTo(existing.id)
                 logger.info("Re-authenticated existing account: \(existing.displayName)")
             } else {
-                logger.warning("Failed to add account (limit reached)")
-                handleOrgDiscoveryFailure("Account limit reached.")
-                showLoginAlert("Account Limit", "You can have up to \(AccountStore.maxAccounts) accounts. Remove one in Settings before adding another.")
-                return
+                // Org ID changed — remove the stale account and add fresh
+                if let stale = accountStore.accounts.first(where: { $0.email == email || $0.email.hasPrefix("Account ") }) {
+                    accountStore.removeAccount(stale.id)
+                    logger.info("Removed stale account: \(stale.displayName)")
+                }
+                if accountStore.addAccount(account) {
+                    accountStore.switchTo(account.id)
+                    logger.info("Account added (replaced stale): \(account.displayName)")
+                } else {
+                    logger.warning("Failed to add account (limit reached)")
+                    handleOrgDiscoveryFailure("Account limit reached.")
+                    showLoginAlert("Account Limit", "You can have up to \(AccountStore.maxAccounts) accounts. Remove one in Settings before adding another.")
+                    return
+                }
             }
 
             // Success — clean up and close window
             pendingSessionKey = nil
+            pendingExpiration = nil
+            pendingCookieHeader = nil
             loginState = .idle
             stopLoginWindow()
         } catch {
@@ -307,6 +346,8 @@ class AuthManager: NSObject, ObservableObject {
 
     private func handleOrgDiscoveryFailure(_ message: String) {
         pendingSessionKey = nil
+        pendingExpiration = nil
+        pendingCookieHeader = nil
         hasCapturedSession = false
         loginState = .error(message)
     }
@@ -321,59 +362,18 @@ class AuthManager: NSObject, ObservableObject {
         alert.beginSheetModal(for: window)
     }
 
-    private func showOrgPicker(orgs: [Organization]) async -> Organization? {
-        guard let window = loginWindowController?.window else { return nil }
-
-        return await withCheckedContinuation { continuation in
-            let alert = NSAlert()
-            alert.messageText = "Choose Organization"
-            alert.informativeText = "Multiple organizations found. Select which one to monitor."
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: "Select")
-            alert.addButton(withTitle: "Cancel")
-
-            let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 300, height: 28), pullsDown: false)
-            for (index, org) in orgs.enumerated() {
-                var title = org.displayName == "Organization" ? "Organization \(index + 1)" : org.displayName
-                // Disambiguate if another org has the same display name
-                let duplicateCount = orgs.prefix(index).filter { $0.displayName == org.displayName && org.displayName != "Organization" }.count
-                if duplicateCount > 0 {
-                    title = "\(title) (\(duplicateCount + 1))"
-                }
-                popup.addItem(withTitle: title)
-            }
-            alert.accessoryView = popup
-
-            alert.beginSheetModal(for: window) { response in
-                if response == .alertFirstButtonReturn {
-                    let selectedIndex = popup.indexOfSelectedItem
-                    guard selectedIndex >= 0, selectedIndex < orgs.count else {
-                        continuation.resume(returning: nil)
-                        return
-                    }
-                    continuation.resume(returning: orgs[selectedIndex])
-                } else {
-                    continuation.resume(returning: nil)
-                }
-            }
-        }
-    }
-
-    private func extractEmail(from orgs: [Organization], rawData: Data) -> String? {
-        // Prefer the enriched model's emailAddress field
-        for org in orgs {
-            if let email = org.emailAddress, !email.isEmpty {
-                return email
-            }
-        }
-        // Fallback: search raw JSON for additional email keys not in the model
-        guard let json = try? JSONSerialization.jsonObject(with: rawData) as? [[String: Any]],
+    private func extractEmail(from data: Data) -> String? {
+        // Try to extract email from the organizations response, checking multiple possible keys
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
               let first = json.first else { return nil }
-        for key in ["email", "billing_email", "primary_email"] {
+
+        let emailKeys = ["email_address", "email", "billing_email", "primary_email"]
+        for key in emailKeys {
             if let email = first[key] as? String, !email.isEmpty {
                 return email
             }
         }
+        // Try nested billing object
         if let billing = first["billing"] as? [String: Any],
            let email = billing["email"] as? String, !email.isEmpty {
             return email
@@ -387,6 +387,7 @@ class AuthManager: NSObject, ObservableObject {
         accountStore.removeAccount(accountId)
         hasCapturedSession = false
         loginState = .idle
+        ClaudeAPI.clearCookies()
         WKWebsiteDataStore.default().removeData(
             ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
             modifiedSince: .distantPast
@@ -399,6 +400,7 @@ class AuthManager: NSObject, ObservableObject {
         for id in ids { accountStore.removeAccount(id) }
         hasCapturedSession = false
         loginState = .idle
+        ClaudeAPI.clearCookies()
         WKWebsiteDataStore.default().removeData(
             ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
             modifiedSince: .distantPast
@@ -422,6 +424,13 @@ class AuthManager: NSObject, ObservableObject {
         host.hasSuffix(".anthropic.com") ||
         host == "accounts.google.com" ||
         host.hasSuffix(".accounts.google.com") ||
+        host == "google.com" ||
+        host.hasSuffix(".google.com") ||
+        host.hasSuffix(".gstatic.com") ||
+        host.hasSuffix(".googleapis.com") ||
+        host.hasSuffix(".googleusercontent.com") ||
+        host == "youtube.com" ||
+        host.hasSuffix(".youtube.com") ||
         host == "appleid.apple.com" ||
         host.hasSuffix(".appleid.apple.com") ||
         host.hasSuffix(".icloud.com") ||
@@ -434,7 +443,18 @@ class AuthManager: NSObject, ObservableObject {
 
 extension AuthManager: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard let url = navigationAction.request.url, let host = url.host else {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        // Allow about:blank and about:srcdoc — used by OAuth flows and iframes
+        if url.scheme == "about" {
+            decisionHandler(.allow)
+            return
+        }
+
+        guard let host = url.host else {
             decisionHandler(.cancel)
             return
         }
@@ -467,8 +487,69 @@ extension AuthManager: WKNavigationDelegate {
             self.loginState = .idle
             self.hasCapturedSession = false
             self.pendingSessionKey = nil
+            self.pendingExpiration = nil
             self.stopLoginWindow()
         }
+    }
+}
+
+// MARK: - WKUIDelegate
+
+extension AuthManager: WKUIDelegate {
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        // Create a real child webview for popups (e.g. Google OAuth).
+        // Using the provided `configuration` preserves `window.opener` so the OAuth
+        // callback can postMessage back to the parent claude.ai page.
+        guard let url = navigationAction.request.url else { return nil }
+
+        if let host = url.host, !isAllowedDomain(host), url.scheme != "about" {
+            logger.info("Blocked popup to disallowed domain: \(host)")
+            return nil
+        }
+
+        let popup = WKWebView(frame: webView.bounds, configuration: configuration)
+        popup.navigationDelegate = self
+        popup.uiDelegate = self
+        popup.autoresizingMask = [.width, .height]
+
+        // Add popup on top of the parent webview so user can interact with it
+        webView.addSubview(popup)
+        self.popupWebView = popup
+
+        logger.debug("Created popup webview for: \(url.host ?? url.absoluteString)")
+        return popup
+    }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        // Called when popup's JavaScript executes window.close() after OAuth callback
+        if webView == popupWebView {
+            logger.debug("Popup webview closed by page")
+            popupWebView?.removeFromSuperview()
+            popupWebView = nil
+        }
+    }
+
+    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
+        guard let window = loginWindowController?.window else {
+            completionHandler()
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.addButton(withTitle: "OK")
+        alert.beginSheetModal(for: window) { _ in completionHandler() }
+    }
+
+    func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+        guard let window = loginWindowController?.window else {
+            completionHandler(false)
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        alert.beginSheetModal(for: window) { response in completionHandler(response == .alertFirstButtonReturn) }
     }
 }
 
@@ -498,6 +579,8 @@ extension AuthManager: NSWindowDelegate {
         if loginState == .signingIn {
             hasCapturedSession = false
             pendingSessionKey = nil
+            pendingExpiration = nil
+            pendingCookieHeader = nil
         }
         loginState = .idle
 
@@ -507,6 +590,8 @@ extension AuthManager: NSWindowDelegate {
         cookiePollTimer = nil
         urlObservation?.invalidate()
         urlObservation = nil
+        popupWebView?.removeFromSuperview()
+        popupWebView = nil
         loginWebView?.stopLoading()
         loginWebView?.configuration.websiteDataStore.httpCookieStore.remove(self)
         loginWebView = nil
@@ -518,25 +603,4 @@ extension AuthManager: NSWindowDelegate {
 
 struct Organization: Codable {
     let uuid: String
-    let name: String?
-    let billingType: String?
-    let emailAddress: String?
-
-    var displayName: String {
-        if let name, !name.isEmpty {
-            let sanitized = name.filter { !$0.isNewline && $0 != "\u{200F}" && $0 != "\u{200E}" }
-            return String(sanitized.prefix(100))
-        }
-        if let billingType, !billingType.isEmpty {
-            return billingType.capitalized
-        }
-        return "Organization"
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case uuid
-        case name
-        case billingType = "billing_type"
-        case emailAddress = "email_address"
-    }
 }

--- a/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
@@ -10,21 +10,58 @@ enum ClaudeAPI {
 
     static let safariUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) \(safariVersionToken) Safari/605.1.15"
 
+    static let safariUserAgentSuffix = "\(safariVersionToken) Safari/605.1.15"
+
+    /// Cookie storage shared across API requests — preserves Cloudflare and CSRF cookies set by responses.
+    private static let cookieStorage = HTTPCookieStorage.shared
+
     static let session: URLSession = {
-        let config = URLSessionConfiguration.ephemeral
-        config.httpShouldSetCookies = false
-        config.httpCookieStorage = nil
-        config.urlCredentialStorage = nil
+        let config = URLSessionConfiguration.default
+        config.httpCookieStorage = cookieStorage
+        config.httpShouldSetCookies = true
+        config.httpCookieAcceptPolicy = .always
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 60
         return URLSession(configuration: config)
     }()
 
-    static func makeRequest(path: String, sessionKey: String) -> URLRequest? {
+    /// Inject login cookies into the shared cookie storage so URLSession sends them automatically.
+    static func injectCookies(from cookieHeader: String, for baseURLString: String = baseURL) {
+        guard URL(string: baseURLString) != nil else { return }
+        let pairs = cookieHeader.components(separatedBy: "; ")
+        for pair in pairs {
+            let parts = pair.components(separatedBy: "=")
+            guard parts.count >= 2 else { continue }
+            let name = parts[0].trimmingCharacters(in: .whitespaces)
+            let value = parts.dropFirst().joined(separator: "=")
+            guard !name.isEmpty, !value.isEmpty else { continue }
+            if let cookie = HTTPCookie(properties: [
+                .name: name,
+                .value: value,
+                .domain: ".claude.ai",
+                .path: "/",
+                .secure: "TRUE",
+            ]) {
+                cookieStorage.setCookie(cookie)
+            }
+        }
+    }
+
+    /// Clear all claude.ai cookies from the storage (used on sign-out).
+    static func clearCookies() {
+        guard let url = URL(string: baseURL) else { return }
+        cookieStorage.cookies(for: url)?.forEach { cookieStorage.deleteCookie($0) }
+    }
+
+    static func makeRequest(path: String, sessionKey: String, cookieHeader: String? = nil) -> URLRequest? {
         guard let url = URL(string: "\(baseURL)\(path)") else { return nil }
+
+        // Ensure login cookies are in the cookie storage
+        injectCookies(from: cookieHeader ?? "sessionKey=\(sessionKey)")
+
         var request = URLRequest(url: url)
-        request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
+        // Don't set Cookie header manually — URLSession merges cookie storage automatically.
         request.setValue("web_claude_ai", forHTTPHeaderField: "anthropic-client-platform")
         request.setValue("1.0.0", forHTTPHeaderField: "anthropic-client-version")
         request.setValue(safariUserAgent, forHTTPHeaderField: "User-Agent")

--- a/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
@@ -14,12 +14,21 @@ struct Account: Codable, Identifiable, Equatable {
     let addedDate: Date
     var notificationThreshold: Double
     var didNotifyBelowThreshold: Bool
+    var sessionKeyExpiration: Date?
+    /// Full cookie header captured from the login WebView (e.g. "sessionKey=abc; __cf_bm=xyz; ...")
+    var allCookieHeader: String?
 
     var displayName: String {
         nickname ?? email
     }
 
-    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false) {
+    /// The Cookie header value to use for API requests.
+    /// Prefers the full captured cookie header; falls back to just sessionKey.
+    var cookieHeaderValue: String {
+        allCookieHeader ?? "sessionKey=\(sessionKey)"
+    }
+
+    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, sessionKeyExpiration: Date? = nil, allCookieHeader: String? = nil) {
         self.id = id
         self.email = email
         self.sessionKey = sessionKey
@@ -28,13 +37,15 @@ struct Account: Codable, Identifiable, Equatable {
         self.addedDate = addedDate
         self.notificationThreshold = notificationThreshold
         self.didNotifyBelowThreshold = didNotifyBelowThreshold
+        self.sessionKeyExpiration = sessionKeyExpiration
+        self.allCookieHeader = allCookieHeader
     }
 }
 
 // MARK: - Storage
 
 final class StorageService {
-    private let defaults: UserDefaults
+    private let defaults = UserDefaults.standard
     private let prefix: String
 
     enum Keys {
@@ -45,9 +56,8 @@ final class StorageService {
         static let migrated = "migrated"
     }
 
-    init(defaults: UserDefaults = .standard, prefix: String = "cb_") {
-        self.defaults = defaults
-        self.prefix = prefix
+    init() {
+        self.prefix = "cb_"
         migrateIfNeeded()
     }
 

--- a/ClaudeBattery/ClaudeBattery/Services/UpdateChecker.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UpdateChecker.swift
@@ -19,7 +19,7 @@ class UpdateChecker: NSObject, ObservableObject {
         static let allowedHosts: Set<String> = ["github.com", "www.github.com"]
     }
 
-    private static let defaultSession: URLSession = {
+    private static let session: URLSession = {
         let config = URLSessionConfiguration.ephemeral
         config.httpShouldSetCookies = false
         config.httpCookieStorage = nil
@@ -29,10 +29,7 @@ class UpdateChecker: NSObject, ObservableObject {
         return URLSession(configuration: config)
     }()
 
-    private let session: any HTTPDataFetching
-
-    init(session: any HTTPDataFetching = UpdateChecker.defaultSession) {
-        self.session = session
+    override init() {
         super.init()
         NSWorkspace.shared.notificationCenter.addObserver(
             self,
@@ -78,7 +75,7 @@ class UpdateChecker: NSObject, ObservableObject {
         request.setValue("claude-battery", forHTTPHeaderField: "User-Agent")
 
         do {
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await Self.session.data(for: request)
 
             guard !Task.isCancelled else { return }
 

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -38,15 +38,13 @@ class UsageService: NSObject, ObservableObject {
 
     private let storage: StorageService
     private let accountStore: AccountStore
-    private let session: any HTTPDataFetching
     private var timer: Timer?
     private var isPolling = false
     private var currentPollTask: Task<Void, Never>?
 
-    init(storage: StorageService, accountStore: AccountStore, session: any HTTPDataFetching = ClaudeAPI.session) {
+    init(storage: StorageService, accountStore: AccountStore) {
         self.storage = storage
         self.accountStore = accountStore
-        self.session = session
         super.init()
 
         NSWorkspace.shared.notificationCenter.addObserver(
@@ -122,14 +120,22 @@ class UsageService: NSObject, ObservableObject {
             return
         }
 
-        guard let request = ClaudeAPI.makeRequest(path: "/api/organizations/\(account.organizationId)/usage", sessionKey: account.sessionKey) else {
+        if let expiration = account.sessionKeyExpiration, expiration < Date() {
+            consecutiveFailures += 1
+            authFailed = true
+            logger.info("Session cookie expired, triggering re-auth")
+            onAuthFailure?()
+            return
+        }
+
+        guard let request = ClaudeAPI.makeRequest(path: "/api/organizations/\(account.organizationId)/usage", sessionKey: account.sessionKey, cookieHeader: account.cookieHeaderValue) else {
             consecutiveFailures += 1
             logger.error("Failed to construct usage API URL")
             return
         }
 
         do {
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await ClaudeAPI.session.data(for: request)
 
             guard !Task.isCancelled else { return }
 
@@ -149,12 +155,8 @@ class UsageService: NSObject, ObservableObject {
 
             guard (200...299).contains(httpResponse.statusCode) else {
                 consecutiveFailures += 1
-                #if DEBUG
                 let body = String(data: data, encoding: .utf8) ?? "(non-utf8)"
                 logger.warning("Unexpected HTTP status: \(httpResponse.statusCode) body: \(body.prefix(500))")
-                #else
-                logger.warning("Unexpected HTTP status: \(httpResponse.statusCode)")
-                #endif
                 return
             }
 
@@ -170,7 +172,20 @@ class UsageService: NSObject, ObservableObject {
 
             guard !Task.isCancelled else { return }
 
-            latestUsage = UsageData(from: usage)
+            // Fetch billing info for prepaid balance
+            var prepaidBalance: Double?
+            let creditsPath = "/api/organizations/\(account.organizationId)/prepaid/credits"
+            if let creditsRequest = ClaudeAPI.makeRequest(path: creditsPath, sessionKey: account.sessionKey, cookieHeader: account.cookieHeaderValue) {
+                if let (creditsData, creditsResponse) = try? await ClaudeAPI.session.data(for: creditsRequest),
+                   let creditsHttp = creditsResponse as? HTTPURLResponse,
+                   (200...299).contains(creditsHttp.statusCode),
+                   let json = try? JSONSerialization.jsonObject(with: creditsData) as? [String: Any],
+                   let amountCents = json["amount"] as? Double {
+                    prepaidBalance = amountCents / 100.0
+                }
+            }
+
+            latestUsage = UsageData(from: usage, prepaidBalance: prepaidBalance)
             lastSuccessfulFetch = Date()
             consecutiveFailures = 0
             authFailed = false
@@ -294,19 +309,19 @@ struct UsageTier: Codable {
 }
 
 struct ExtraUsageData {
-    let spent: Double
-    let limit: Double
+    let balance: Double
+    let monthlyLimit: Double
     let percentage: Double
 
-    init?(from tier: ExtraUsageTier?) {
+    init?(from tier: ExtraUsageTier?, prepaidBalance: Double?) {
         guard let tier, tier.isEnabled == true,
-              let spentCents = tier.usedCredits,
+              let balance = prepaidBalance,
               let limitCents = tier.monthlyLimit,
               limitCents > 0 else { return nil }
 
-        self.spent = spentCents / 100.0
-        self.limit = limitCents / 100.0
-        self.percentage = min(100, max(0, spentCents / limitCents * 100))
+        self.balance = balance
+        self.monthlyLimit = limitCents / 100.0
+        self.percentage = min(100, max(0, balance / self.monthlyLimit * 100))
     }
 }
 
@@ -321,7 +336,7 @@ struct UsageData {
     let sonnetResetDate: Date?
     let extraUsage: ExtraUsageData?
 
-    init(from response: UsageResponse) {
+    init(from response: UsageResponse, prepaidBalance: Double? = nil) {
         weeklyRemaining = max(0, min(100, 100 - (response.sevenDay?.utilization ?? 0)))
         weeklyResetDate = response.sevenDay?.resetsAt
         sessionRemaining = max(0, min(100, 100 - (response.fiveHour?.utilization ?? 0)))
@@ -330,6 +345,6 @@ struct UsageData {
         opusResetDate = response.sevenDayOpus?.resetsAt
         sonnetRemaining = max(0, min(100, 100 - (response.sevenDaySonnet?.utilization ?? 0)))
         sonnetResetDate = response.sevenDaySonnet?.resetsAt
-        extraUsage = ExtraUsageData(from: response.extraUsage)
+        extraUsage = ExtraUsageData(from: response.extraUsage, prepaidBalance: prepaidBalance)
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Views/SettingsView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/SettingsView.swift
@@ -29,9 +29,9 @@ struct SettingsView: View {
                     .onAppear {
                         launchAtLogin = SMAppService.mainApp.status == .enabled
                     }
-                    .onChange(of: launchAtLogin) { newValue in
+                    .onChange(of: launchAtLogin) {
                         do {
-                            if newValue {
+                            if launchAtLogin {
                                 try SMAppService.mainApp.register()
                             } else {
                                 try SMAppService.mainApp.unregister()
@@ -44,8 +44,8 @@ struct SettingsView: View {
 
             Section {
                 Toggle("Low usage notifications", isOn: $notificationsEnabled)
-                    .onChange(of: notificationsEnabled) { newValue in
-                        if newValue {
+                    .onChange(of: notificationsEnabled) {
+                        if notificationsEnabled {
                             UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
                         }
                     }

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -169,12 +169,6 @@ struct UsagePopoverView: View {
         return .green
     }
 
-    private func spendColor(for percent: Double) -> Color {
-        if percent >= 80 { return .red }
-        if percent >= 50 { return .orange }
-        return .cyan
-    }
-
     private static let currencyFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
@@ -196,10 +190,10 @@ struct UsagePopoverView: View {
                     .foregroundColor(Color(white: 0.6))
                 Spacer()
                 HStack(spacing: 0) {
-                    Text(formatCurrency(extraUsage.spent))
+                    Text(formatCurrency(extraUsage.balance))
                         .font(.system(size: 11, weight: .semibold, design: .rounded))
                         .foregroundColor(.white)
-                    Text(" / \(formatCurrency(extraUsage.limit))")
+                    Text(" balance")
                         .font(.system(size: 10, weight: .regular))
                         .foregroundColor(Color(white: 0.45))
                 }
@@ -209,7 +203,7 @@ struct UsagePopoverView: View {
                     RoundedRectangle(cornerRadius: 3)
                         .fill(Color(white: 0.25))
                     RoundedRectangle(cornerRadius: 3)
-                        .fill(spendColor(for: extraUsage.percentage))
+                        .fill(gaugeColor(for: extraUsage.percentage))
                         .frame(width: max(0, geo.size.width * extraUsage.percentage / 100))
                 }
             }


### PR DESCRIPTION
Here are the changes that make both login methods work for me, plus some other changes (mainly the extra usage functionality).

Overhaul authentication to capture full cookie headers from the login WebView (Cloudflare, CSRF tokens) and use shared HTTPCookieStorage instead of manual Cookie headers. Add WKUIDelegate popup support for Google OAuth flows. Replace org picker with automatic usage-endpoint probing to find the active subscription. Fetch prepaid credit balance from /prepaid/credits and display as "balance" in the popover. Remove test target, HTTPDataFetching protocol, and DI seams. Update to macOS 26.0 deployment target and modern SwiftUI onChange syntax.