### PR TITLE
fix: restart polling after re-auth, show auth failure in icon (issue #10)

### DIFF
--- a/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
+++ b/ClaudeBattery/ClaudeBattery/App/ClaudeBatteryApp.swift
@@ -42,6 +42,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.authManager.handleAuthFailure()
         }
 
+        // Wire auth success callback — restarts polling after any successful
+        // authentication, including re-auth to the same org where $activeAccountId
+        // doesn't change and the Combine subscriber below won't fire.
+        authManager.onAuthSuccess = { [weak self] in
+            self?.usageService.switchAccount()
+        }
+
         updateChecker = UpdateChecker()
         updateChecker.startChecking()
 
@@ -55,9 +62,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Set notification delegate early
         UNUserNotificationCenter.current().delegate = usageService
 
-        // Start polling if we have an active account
+        // Start polling if we have an active account, or auto-present
+        // sign-in if this is a fresh install with no accounts
         if accountStore.activeAccount != nil {
             usageService.startPolling()
+        } else if accountStore.accounts.isEmpty {
+            authManager.presentLogin()
         }
 
         // Observe active account changes to start/stop polling

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -28,6 +28,7 @@ class AuthManager: NSObject, ObservableObject {
     private var hasCapturedSession = false
     // internal for @testable access in AuthManagerTests
     var pendingSessionKey: String?
+    var onAuthSuccess: (() -> Void)?
 
     init(storage: StorageService, accountStore: AccountStore, session: any HTTPDataFetching = ClaudeAPI.session) {
         self.storage = storage
@@ -323,10 +324,11 @@ class AuthManager: NSObject, ObservableObject {
                 return
             }
 
-            // Success — clean up and close window
+            // Success — clean up, close window, and notify
             pendingSessionKey = nil
             loginState = .idle
             stopLoginWindow()
+            onAuthSuccess?()
         } catch {
             guard !Task.isCancelled else { return }
             logger.error("Org discovery failed: \(error.localizedDescription)")

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -142,6 +142,7 @@ class UsageService: NSObject, ObservableObject {
             if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                 consecutiveFailures += 1
                 authFailed = true
+                latestUsage = nil
                 logger.warning("Auth failure (HTTP \(httpResponse.statusCode)) for \(account.displayName)")
                 onAuthFailure?()
                 return

--- a/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
@@ -73,9 +73,11 @@ class MenuBarController: NSObject {
     private func setupObservers() {
         usageService.$latestUsage
             .combineLatest(usageService.$consecutiveFailures, accountStore.$activeAccountId)
+            .combineLatest(usageService.$authFailed)
             .receive(on: RunLoop.main)
-            .sink { [weak self] usage, _, activeId in
-                self?.updateIcon(usage, isAuthenticated: activeId != nil)
+            .sink { [weak self] combined, authFailed in
+                let (usage, _, activeId) = combined
+                self?.updateIcon(usage, isAuthenticated: activeId != nil, authFailed: authFailed)
             }
             .store(in: &cancellables)
 
@@ -87,7 +89,7 @@ class MenuBarController: NSObject {
                 guard let self else { return }
                 let currentStyle = UserDefaults.standard.string(forKey: "iconStyle") ?? IconStyle.dualHorizontal.rawValue
                 guard currentStyle != self.lastRenderedStyle else { return }
-                self.updateIcon(self.usageService.latestUsage, isAuthenticated: self.accountStore.isAuthenticated)
+                self.updateIcon(self.usageService.latestUsage, isAuthenticated: self.accountStore.isAuthenticated, authFailed: self.usageService.authFailed)
             }
         }
 
@@ -99,7 +101,7 @@ class MenuBarController: NSObject {
             guard change.oldValue?.name != change.newValue?.name else { return }
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.updateIcon(self.usageService.latestUsage, isAuthenticated: self.accountStore.isAuthenticated)
+                self.updateIcon(self.usageService.latestUsage, isAuthenticated: self.accountStore.isAuthenticated, authFailed: self.usageService.authFailed)
             }
         }
     }
@@ -193,7 +195,7 @@ class MenuBarController: NSObject {
 
     // MARK: - Icon Rendering
 
-    private func updateIcon(_ usage: UsageData?, isAuthenticated: Bool) {
+    private func updateIcon(_ usage: UsageData?, isAuthenticated: Bool, authFailed: Bool = false) {
         let style = IconStyle(rawValue: iconStyleRaw) ?? .dualHorizontal
         let renderer = style.renderer
         let color = iconColor
@@ -201,6 +203,8 @@ class MenuBarController: NSObject {
 
         if !isAuthenticated {
             image = renderer.makeUnauthenticatedIcon(color: color)
+        } else if authFailed {
+            image = renderer.makeStatusIcon(text: "!", color: color, alpha: 0.5)
         } else if let usage = usage {
             image = renderer.makeBatteryIcon(usage: usage, color: color)
         } else if usageService.consecutiveFailures >= 10 {

--- a/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
@@ -162,6 +162,9 @@ final class AuthManagerTests: XCTestCase {
 
         await auth.fetchOrganizationId()
 
+        // With multiple orgs and no login window (test context), the org picker
+        // returns nil because loginWindowController is nil. This triggers
+        // handleOrgDiscoveryFailure, so no account is created.
         let store = auth.accountStore
         XCTAssertEqual(store.accounts.count, 0,
                        "No account created when org picker has no window")
@@ -344,6 +347,96 @@ final class AuthManagerTests: XCTestCase {
     func testIsDashboardURL_httpScheme() {
         let url = URL(string: "http://claude.ai/chat")!
         XCTAssertFalse(AuthManager.isDashboardURL(url))
+    }
+
+    // MARK: - onAuthSuccess callback
+
+    @MainActor
+    func testOnAuthSuccess_firesAfterSingleOrgAuth() async {
+        let auth = makeAuthManager()
+        var callbackFired = false
+        auth.onAuthSuccess = { callbackFired = true }
+
+        let json = """
+        [{"uuid": "org-success-111"}]
+        """.data(using: .utf8)!
+
+        mockSession.responseData = json
+        mockSession.responseStatusCode = 200
+        auth.pendingSessionKey = "sk-new"
+
+        await auth.fetchOrganizationId()
+
+        XCTAssertTrue(callbackFired, "onAuthSuccess should fire after single-org auth")
+    }
+
+    @MainActor
+    func testOnAuthSuccess_firesAfterReAuthToSameOrg() async {
+        let auth = makeAuthManager()
+        let store = auth.accountStore
+
+        // Pre-populate an account
+        let existing = Account(email: "test@test.com", sessionKey: "sk-old", organizationId: "org-reauth-789")
+        _ = store.addAccount(existing)
+
+        var callbackFired = false
+        auth.onAuthSuccess = { callbackFired = true }
+
+        let json = """
+        [{"uuid": "org-reauth-789"}]
+        """.data(using: .utf8)!
+
+        mockSession.responseData = json
+        mockSession.responseStatusCode = 200
+        auth.pendingSessionKey = "sk-refreshed"
+
+        await auth.fetchOrganizationId()
+
+        XCTAssertTrue(callbackFired, "onAuthSuccess should fire after re-auth to same org")
+    }
+
+    @MainActor
+    func testOnAuthSuccess_doesNotFireOnFailure() async {
+        let auth = makeAuthManager()
+        var callbackFired = false
+        auth.onAuthSuccess = { callbackFired = true }
+
+        mockSession.responseData = Data()
+        mockSession.responseStatusCode = 401
+        auth.pendingSessionKey = "sk-bad"
+
+        await auth.fetchOrganizationId()
+
+        XCTAssertFalse(callbackFired, "onAuthSuccess should NOT fire on auth failure")
+    }
+
+    @MainActor
+    func testOnAuthSuccess_doesNotFireOnEmptyOrgs() async {
+        let auth = makeAuthManager()
+        var callbackFired = false
+        auth.onAuthSuccess = { callbackFired = true }
+
+        mockSession.responseData = "[]".data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+        auth.pendingSessionKey = "sk-empty"
+
+        await auth.fetchOrganizationId()
+
+        XCTAssertFalse(callbackFired, "onAuthSuccess should NOT fire when no orgs found")
+    }
+
+    @MainActor
+    func testOnAuthSuccess_doesNotFireOnNetworkError() async {
+        let auth = makeAuthManager()
+        var callbackFired = false
+        auth.onAuthSuccess = { callbackFired = true }
+
+        mockSession.responseError = URLError(.notConnectedToInternet)
+        auth.pendingSessionKey = "sk-offline"
+
+        await auth.fetchOrganizationId()
+
+        XCTAssertFalse(callbackFired, "onAuthSuccess should NOT fire on network error")
     }
 
     // MARK: - LoginState equality

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -460,6 +460,57 @@ final class UsageServicePollTests: XCTestCase {
         XCTAssertEqual(extra.percentage, 75.0, accuracy: 0.01)
     }
 
+    // MARK: - Auth failure clears latestUsage
+
+    @MainActor
+    func testPoll401_clearsLatestUsage() async {
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        // First, get some usage data
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        await service.pollUsage()
+        XCTAssertNotNil(service.latestUsage, "Should have usage data after successful poll")
+
+        // Now simulate auth failure
+        mockSession.responseData = Data()
+        mockSession.responseStatusCode = 401
+        await service.pollUsage()
+
+        XCTAssertTrue(service.authFailed)
+        XCTAssertNil(service.latestUsage,
+                     "latestUsage should be cleared on auth failure so popover shows re-auth screen")
+    }
+
+    // MARK: - switchAccount resets authFailed
+
+    @MainActor
+    func testSwitchAccount_resetsAuthFailedAndConsecutiveFailures() async {
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        // Simulate auth failure state
+        mockSession.responseData = Data()
+        mockSession.responseStatusCode = 401
+        await service.pollUsage()
+        XCTAssertTrue(service.authFailed)
+        XCTAssertEqual(service.consecutiveFailures, 1)
+
+        // switchAccount should reset everything
+        service.switchAccount()
+
+        XCTAssertFalse(service.authFailed, "switchAccount should clear authFailed")
+        XCTAssertEqual(service.consecutiveFailures, 0, "switchAccount should reset consecutiveFailures")
+        XCTAssertNil(service.latestUsage, "switchAccount should clear latestUsage")
+    }
+
     // MARK: - Helpers
 
     private func fixtureData(_ name: String) -> Data {


### PR DESCRIPTION
## Summary

Fixes the invisible menu bar icon after upgrading from v1.44 to v1.45 (issue #10).

**Root cause:** Re-authenticating to the same org called `AccountStore.switchTo()` with the same UUID. `@Published` deduplication meant the Combine subscriber never fired, `UsageService.switchAccount()` was never called, and polling stayed dead after session expiry.

**Changes:**
- Add `onAuthSuccess` callback to AuthManager (matching existing `onAuthFailure` pattern), wired in AppDelegate to call `usageService.switchAccount()` unconditionally
- Clear `latestUsage` on auth failure so the popover shows the re-auth screen instead of stale data
- Add `$authFailed` to MenuBarController's Combine observer - icon shows "!" on auth failure
- Auto-present sign-in window on first launch when no accounts exist

115 tests pass (7 new tests for onAuthSuccess callback, auth failure clearing latestUsage, and switchAccount state reset).

## Test plan

- [ ] Fresh install: sign-in window appears automatically, login succeeds, icon shows battery
- [ ] Upgrade from v1.44 with stale session: icon shows "!" after 401, click shows re-auth screen, re-login restarts polling
- [ ] Multi-org re-auth to same org: polling restarts (the core bug scenario)
- [ ] Multi-org re-auth to different org: polling starts for new org
- [ ] Single-monitor: no regression in normal icon rendering

Closes #10