### PR TITLE
fix: sign-in hardening, OAuth popup, prepaid balance, crash fix (issue #7)

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
@@ -36,6 +36,13 @@ class AccountStore: ObservableObject {
             activeAccountId = first.id
             storage.setActiveAccountId(first.id)
         }
+
+        // Prime the ClaudeAPI cookie jar from the active account's captured cookies.
+        // Runs at app launch so the first /usage poll after boot carries the full cookie set
+        // (sessionKey + Cloudflare __cf_bm etc.), not sessionKey alone.
+        if let active = activeAccount {
+            ClaudeAPI.activateCookies(sessionKey: active.sessionKey, cookieHeader: active.allCookieHeader)
+        }
     }
 
     // MARK: - Mutations
@@ -65,11 +72,17 @@ class AccountStore: ObservableObject {
     }
 
     func removeAccount(_ id: UUID) {
+        let wasActive = (activeAccountId == id)
         accounts.removeAll(where: { $0.id == id })
 
-        if activeAccountId == id {
+        if wasActive {
             activeAccountId = accounts.first?.id
             storage.setActiveAccountId(activeAccountId)
+            if let newActive = activeAccount {
+                ClaudeAPI.activateCookies(sessionKey: newActive.sessionKey, cookieHeader: newActive.allCookieHeader)
+            } else {
+                ClaudeAPI.clearClaudeCookies()
+            }
         }
 
         persist()
@@ -77,16 +90,27 @@ class AccountStore: ObservableObject {
     }
 
     func switchTo(_ id: UUID) {
-        guard accounts.contains(where: { $0.id == id }) else { return }
+        guard let account = accounts.first(where: { $0.id == id }) else { return }
         activeAccountId = id
         storage.setActiveAccountId(id)
+        ClaudeAPI.activateCookies(sessionKey: account.sessionKey, cookieHeader: account.allCookieHeader)
         logger.info("Switched to account \(id.uuidString)")
     }
 
-    func updateSessionKey(_ id: UUID, _ sessionKey: String) {
+    func updateSessionKey(_ id: UUID, _ sessionKey: String, cookieHeader: String? = nil, expiration: Date? = nil) {
         guard let index = accounts.firstIndex(where: { $0.id == id }) else { return }
         accounts[index].sessionKey = sessionKey
+        if let cookieHeader {
+            accounts[index].allCookieHeader = cookieHeader
+        }
+        if let expiration {
+            accounts[index].sessionKeyExpiration = expiration
+        }
         persist()
+        if activeAccountId == id {
+            // Re-prime the cookie jar with the fresh credentials so the next API call uses them.
+            ClaudeAPI.activateCookies(sessionKey: sessionKey, cookieHeader: accounts[index].allCookieHeader)
+        }
     }
 
     func updateNickname(_ id: UUID, _ nickname: String) {

--- a/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
@@ -97,14 +97,11 @@ class AccountStore: ObservableObject {
         logger.info("Switched to account \(id.uuidString)")
     }
 
-    func updateSessionKey(_ id: UUID, _ sessionKey: String, cookieHeader: String? = nil, expiration: Date? = nil) {
+    func updateSessionKey(_ id: UUID, _ sessionKey: String, cookieHeader: String? = nil) {
         guard let index = accounts.firstIndex(where: { $0.id == id }) else { return }
         accounts[index].sessionKey = sessionKey
         if let cookieHeader {
             accounts[index].allCookieHeader = cookieHeader
-        }
-        if let expiration {
-            accounts[index].sessionKeyExpiration = expiration
         }
         persist()
         if activeAccountId == id {

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -63,7 +63,8 @@ class AuthManager: NSObject, ObservableObject {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
 
-        // Debug DMG instrumentation - capture every fetch / XHR inside the login webview
+        #if DEBUG
+        // Debug instrumentation - capture every fetch / XHR inside the login webview
         // so we can see which claude.ai request fails when a user reports "error logging you in"
         // inside the UI (e.g., samuelgjekic, issue #7). Logs arrive via os_log with subsystem
         // "com.claudebattery.app", category "Auth", visible in Console.app or `log stream`.
@@ -117,16 +118,17 @@ class AuthManager: NSObject, ObservableObject {
         let userScript = WKUserScript(source: netLogScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         config.userContentController.addUserScript(userScript)
         config.userContentController.add(self, name: "claudebatteryNetLog")
+        #endif
 
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 640), configuration: config)
         webView.customUserAgent = ClaudeAPI.safariUserAgent
         webView.navigationDelegate = self
         webView.uiDelegate = self
-        // Lets users open the Web Inspector on the login webview via Safari > Develop menu
-        // (or via a right-click context menu on macOS 13.3+). Debug-DMG-only - never ship enabled.
+        #if DEBUG
         if #available(macOS 13.3, *) {
             webView.isInspectable = true
         }
+        #endif
         self.loginWebView = webView
 
         config.websiteDataStore.httpCookieStore.add(self)
@@ -239,6 +241,9 @@ class AuthManager: NSObject, ObservableObject {
         popupWebView = nil
         loginWebView?.stopLoading()
         loginWebView?.configuration.websiteDataStore.httpCookieStore.remove(self)
+        #if DEBUG
+        loginWebView?.configuration.userContentController.removeScriptMessageHandler(forName: "claudebatteryNetLog")
+        #endif
         loginWebView = nil
         loginWindowController?.close()
         loginWindowController = nil
@@ -250,12 +255,12 @@ class AuthManager: NSObject, ObservableObject {
         (cookie.domain == "claude.ai" || cookie.domain == ".claude.ai")
     }
 
-    /// Any cookie scoped to claude.ai (exact, leading-dot, or any sub-domain).
+    /// Any cookie scoped to claude.ai (exact or leading-dot only).
     /// Used when building the full Cookie header after capture.
+    /// Per Critical Pattern #2: never use hasSuffix for domain validation -
+    /// hasSuffix(".claude.ai") would match evil-claude.ai.
     static func isClaudeCookie(_ cookie: HTTPCookie) -> Bool {
-        cookie.domain == "claude.ai" ||
-        cookie.domain == ".claude.ai" ||
-        cookie.domain.hasSuffix(".claude.ai")
+        cookie.domain == "claude.ai" || cookie.domain == ".claude.ai"
     }
 
     // internal for @testable access in AuthManagerTests
@@ -280,9 +285,12 @@ class AuthManager: NSObject, ObservableObject {
         // Enumerate every `.claude.ai` cookie into a Cookie header string so authenticated
         // API requests carry the full set (including Cloudflare `__cf_bm`) - not `sessionKey`
         // alone. Then kick off org discovery.
+        // Capture loginWebView before the first await so a concurrent stopLoginWindow call
+        // that nils the property does not cause us to skip cookie enumeration (COR-002).
+        let capturedWebView = self.loginWebView
         Task { [weak self] in
             guard let self else { return }
-            if let webView = self.loginWebView {
+            if let webView = capturedWebView {
                 let allCookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
                 let claudeCookies = allCookies.filter(Self.isClaudeCookie)
                 let header = claudeCookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
@@ -621,9 +629,18 @@ extension AuthManager: WKUIDelegate {
         guard let url = navigationAction.request.url else { return nil }
 
         // Apply the same allowlist as the parent WebView. OAuth popups must not escape to
-        // arbitrary domains. `about:` URIs are allowed here (handled by decidePolicyFor on
-        // the child's navigationDelegate).
-        if let host = url.host, !isAllowedDomain(host), url.scheme != "about" {
+        // arbitrary domains. Require a host (blocks javascript:, data:, blob: URIs) or
+        // allow about: (handled by decidePolicyFor on the child's navigationDelegate).
+        guard let host = url.host else {
+            if url.scheme == "about" { /* fall through to popup creation */ }
+            else {
+                logger.info("Blocked popup with no host: \(url.scheme ?? "nil")")
+                return nil
+            }
+            // about: URIs with no host are allowed — continue to popup creation below
+            return nil // placeholder; about: with no host is uncommon, block conservatively
+        }
+        if !isAllowedDomain(host) {
             logger.info("Blocked popup to disallowed domain: \(host)")
             return nil
         }
@@ -637,9 +654,11 @@ extension AuthManager: WKUIDelegate {
         popup.uiDelegate = self
         popup.customUserAgent = ClaudeAPI.safariUserAgent
         popup.autoresizingMask = [.width, .height]
+        #if DEBUG
         if #available(macOS 13.3, *) {
-            popup.isInspectable = true  // debug-DMG only
+            popup.isInspectable = true
         }
+        #endif
         webView.addSubview(popup)
         self.popupWebView = popup
 

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -754,7 +754,11 @@ extension AuthManager: NSWindowDelegate {
         }
         loginState = .idle
 
-        // Delegate all resource cleanup to stopLoginWindow (single teardown path)
+        // Nil the window controller BEFORE calling stopLoginWindow to break the
+        // recursion cycle: stopLoginWindow calls close() which triggers windowWillClose.
+        loginWindowController = nil
+
+        // Delegate remaining resource cleanup to stopLoginWindow (single teardown path)
         stopLoginWindow()
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -28,6 +28,17 @@ class AuthManager: NSObject, ObservableObject {
     private var hasCapturedSession = false
     // internal for @testable access in AuthManagerTests
     var pendingSessionKey: String?
+    /// Full Cookie header string built from every `.claude.ai` cookie in the login WebView
+    /// (or the full `document.cookie` string in the JS-fallback path). Passed to `ClaudeAPI`
+    /// alongside `pendingSessionKey` so authenticated API calls during org discovery carry
+    /// the full cookie set instead of `sessionKey` alone.
+    private var pendingCookieHeader: String?
+    /// Child WebView hosting OAuth popups spawned by `window.open()`. Added as a subview of
+    /// the primary `loginWebView` so the OAuth provider's callback can `postMessage` back to
+    /// the claude.ai page via `window.opener`. Torn down on `webViewDidClose` or login-window
+    /// shutdown. Required for "Continue with Google" - without it, `window.open()` returns nil
+    /// and Google OAuth fails immediately.
+    private var popupWebView: WKWebView?
 
     init(storage: StorageService, accountStore: AccountStore, session: any HTTPDataFetching = ClaudeAPI.session) {
         self.storage = storage
@@ -52,9 +63,70 @@ class AuthManager: NSObject, ObservableObject {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
 
+        // Debug DMG instrumentation - capture every fetch / XHR inside the login webview
+        // so we can see which claude.ai request fails when a user reports "error logging you in"
+        // inside the UI (e.g., samuelgjekic, issue #7). Logs arrive via os_log with subsystem
+        // "com.claudebattery.app", category "Auth", visible in Console.app or `log stream`.
+        let netLogScript = """
+        (function() {
+            const post = (data) => {
+                try {
+                    const h = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.claudebatteryNetLog;
+                    if (h) h.postMessage(JSON.stringify(data));
+                } catch (e) {}
+            };
+            post({kind: 'script-injected', url: location.href});
+            const origFetch = window.fetch;
+            window.fetch = async function(input, init) {
+                const url = typeof input === 'string' ? input : (input && input.url) || '';
+                const method = (init && init.method) || (typeof input === 'object' && input.method) || 'GET';
+                post({kind: 'fetch-start', url, method});
+                try {
+                    const response = await origFetch(input, init);
+                    post({kind: 'fetch-done', url, method, status: response.status});
+                    return response;
+                } catch (e) {
+                    post({kind: 'fetch-error', url, method, error: String(e)});
+                    throw e;
+                }
+            };
+            const OrigXHR = window.XMLHttpRequest;
+            window.XMLHttpRequest = function() {
+                const xhr = new OrigXHR();
+                const origOpen = xhr.open;
+                xhr.open = function(method, url) {
+                    this._method = method; this._url = url;
+                    post({kind: 'xhr-open', method, url});
+                    return origOpen.apply(this, arguments);
+                };
+                xhr.addEventListener('loadend', function() {
+                    post({kind: 'xhr-done', method: xhr._method, url: xhr._url, status: xhr.status});
+                });
+                return xhr;
+            };
+            window.addEventListener('error', function(ev) {
+                post({kind: 'js-error', message: String(ev.message), source: String(ev.filename || ''), lineno: ev.lineno || 0});
+            });
+            const origConsoleError = console.error;
+            console.error = function() {
+                try { post({kind: 'console-error', args: Array.from(arguments).map(a => String(a)).join(' ') }); } catch (e) {}
+                return origConsoleError.apply(console, arguments);
+            };
+        })();
+        """
+        let userScript = WKUserScript(source: netLogScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        config.userContentController.addUserScript(userScript)
+        config.userContentController.add(self, name: "claudebatteryNetLog")
+
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 640), configuration: config)
         webView.customUserAgent = ClaudeAPI.safariUserAgent
         webView.navigationDelegate = self
+        webView.uiDelegate = self
+        // Lets users open the Web Inspector on the login webview via Safari > Develop menu
+        // (or via a right-click context menu on macOS 13.3+). Debug-DMG-only - never ship enabled.
+        if #available(macOS 13.3, *) {
+            webView.isInspectable = true
+        }
         self.loginWebView = webView
 
         config.websiteDataStore.httpCookieStore.add(self)
@@ -138,6 +210,12 @@ class AuthManager: NSObject, ObservableObject {
                     logger.info("Session cookie captured via JavaScript fallback")
                     self.hasCapturedSession = true
                     self.pendingSessionKey = value
+                    // JS path: `document.cookie` only exposes non-HttpOnly cookies, which
+                    // excludes Cloudflare `__cf_bm`. Pass whatever we can see to `ClaudeAPI`;
+                    // it primes the jar with this set, then URLSession picks up the HttpOnly
+                    // cookies (including `__cf_bm`) automatically from the ambient
+                    // `WKWebsiteDataStore` context on the first authenticated response.
+                    self.pendingCookieHeader = cookieString
                     self.loginState = .signingIn
                     self.cookiePollTimer?.invalidate()
                     self.cookiePollTimer = nil
@@ -156,6 +234,9 @@ class AuthManager: NSObject, ObservableObject {
         cookiePollTimer = nil
         urlObservation?.invalidate()
         urlObservation = nil
+        popupWebView?.stopLoading()
+        popupWebView?.removeFromSuperview()
+        popupWebView = nil
         loginWebView?.stopLoading()
         loginWebView?.configuration.websiteDataStore.httpCookieStore.remove(self)
         loginWebView = nil
@@ -167,6 +248,14 @@ class AuthManager: NSObject, ObservableObject {
     static func isSessionCookie(_ cookie: HTTPCookie) -> Bool {
         cookie.name == "sessionKey" &&
         (cookie.domain == "claude.ai" || cookie.domain == ".claude.ai")
+    }
+
+    /// Any cookie scoped to claude.ai (exact, leading-dot, or any sub-domain).
+    /// Used when building the full Cookie header after capture.
+    static func isClaudeCookie(_ cookie: HTTPCookie) -> Bool {
+        cookie.domain == "claude.ai" ||
+        cookie.domain == ".claude.ai" ||
+        cookie.domain.hasSuffix(".claude.ai")
     }
 
     // internal for @testable access in AuthManagerTests
@@ -188,7 +277,20 @@ class AuthManager: NSObject, ObservableObject {
 
         logger.info("Session cookie captured via cookie store")
 
-        orgDiscoveryTask = Task { await fetchOrganizationId() }
+        // Enumerate every `.claude.ai` cookie into a Cookie header string so authenticated
+        // API requests carry the full set (including Cloudflare `__cf_bm`) - not `sessionKey`
+        // alone. Then kick off org discovery.
+        Task { [weak self] in
+            guard let self else { return }
+            if let webView = self.loginWebView {
+                let allCookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
+                let claudeCookies = allCookies.filter(Self.isClaudeCookie)
+                let header = claudeCookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+                self.pendingCookieHeader = header.isEmpty ? nil : header
+                logger.info("Captured \(claudeCookies.count) .claude.ai cookies for API requests")
+            }
+            self.orgDiscoveryTask = Task { await self.fetchOrganizationId() }
+        }
     }
 
     // MARK: - Org Discovery
@@ -201,7 +303,7 @@ class AuthManager: NSObject, ObservableObject {
             return
         }
 
-        guard let request = ClaudeAPI.makeRequest(path: "/api/organizations", sessionKey: sessionKey) else {
+        guard let request = ClaudeAPI.makeRequest(path: "/api/organizations", sessionKey: sessionKey, cookieHeader: pendingCookieHeader) else {
             logger.error("Failed to construct organizations API URL")
             handleOrgDiscoveryFailure("Connection error. Please try again.")
             showLoginAlert("Connection Error", "Could not complete sign-in. Please close this window and try again.")
@@ -275,15 +377,18 @@ class AuthManager: NSObject, ObservableObject {
             let account = Account(
                 email: email,
                 sessionKey: sessionKey,
-                organizationId: chosenOrg.uuid
+                organizationId: chosenOrg.uuid,
+                allCookieHeader: pendingCookieHeader
             )
 
             if accountStore.addAccount(account) {
                 accountStore.switchTo(account.id)
                 logger.info("Account added and activated: \(account.displayName)")
             } else if let existing = accountStore.accounts.first(where: { $0.organizationId == chosenOrg.uuid }) {
-                // Re-authentication: update session key on existing account
-                accountStore.updateSessionKey(existing.id, sessionKey)
+                // Re-authentication: update session key AND the full cookie header so the next
+                // API call primes the jar with the fresh Cloudflare / CSRF cookies, not the stale
+                // pair that was paired with the previous sessionKey.
+                accountStore.updateSessionKey(existing.id, sessionKey, cookieHeader: pendingCookieHeader)
                 accountStore.switchTo(existing.id)
                 logger.info("Re-authenticated existing account: \(existing.displayName)")
             } else {
@@ -295,6 +400,7 @@ class AuthManager: NSObject, ObservableObject {
 
             // Success — clean up and close window
             pendingSessionKey = nil
+            pendingCookieHeader = nil
             loginState = .idle
             stopLoginWindow()
         } catch {
@@ -307,6 +413,7 @@ class AuthManager: NSObject, ObservableObject {
 
     private func handleOrgDiscoveryFailure(_ message: String) {
         pendingSessionKey = nil
+        pendingCookieHeader = nil
         hasCapturedSession = false
         loginState = .error(message)
     }
@@ -416,12 +523,21 @@ class AuthManager: NSObject, ObservableObject {
     // MARK: - Allowed Domains
 
     private func isAllowedDomain(_ host: String) -> Bool {
-        // hasSuffix is acceptable here — false positives only show content, not leak credentials.
+        // Exact match plus `".X"` suffix for multi-label domains - rejects
+        // attacker-injected prefixes like `evil.googleapis.com.attacker.com`
+        // that a bare `hasSuffix(".googleapis.com")` would accept.
         host == "claude.ai" ||
         host.hasSuffix(".claude.ai") ||
         host.hasSuffix(".anthropic.com") ||
         host == "accounts.google.com" ||
         host.hasSuffix(".accounts.google.com") ||
+        host == "google.com" ||
+        host.hasSuffix(".google.com") ||
+        host.hasSuffix(".gstatic.com") ||
+        host.hasSuffix(".googleapis.com") ||
+        host.hasSuffix(".googleusercontent.com") ||
+        host == "youtube.com" ||
+        host.hasSuffix(".youtube.com") ||
         host == "appleid.apple.com" ||
         host.hasSuffix(".appleid.apple.com") ||
         host.hasSuffix(".icloud.com") ||
@@ -434,7 +550,27 @@ class AuthManager: NSObject, ObservableObject {
 
 extension AuthManager: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard let url = navigationAction.request.url, let host = url.host else {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        // Allow OAuth blank-frame bootstraps (about:blank / about:srcdoc). These appear as
+        // intermediate frames during Google's OAuth flow; blocking them breaks the popup.
+        if url.scheme == "about" {
+            let absoluteString = url.absoluteString
+            if absoluteString == "about:" ||
+               absoluteString.hasPrefix("about:blank") ||
+               absoluteString.hasPrefix("about:srcdoc") {
+                decisionHandler(.allow)
+            } else {
+                logger.info("Blocked navigation to unusual about: URI: \(absoluteString)")
+                decisionHandler(.cancel)
+            }
+            return
+        }
+
+        guard let host = url.host else {
             decisionHandler(.cancel)
             return
         }
@@ -467,8 +603,103 @@ extension AuthManager: WKNavigationDelegate {
             self.loginState = .idle
             self.hasCapturedSession = false
             self.pendingSessionKey = nil
+            self.pendingCookieHeader = nil
             self.stopLoginWindow()
         }
+    }
+}
+
+// MARK: - WKUIDelegate
+
+extension AuthManager: WKUIDelegate {
+    /// Handle `window.open()` requests from the login WebView. Google "Continue with Google"
+    /// uses this to spawn its OAuth flow as a popup; if we return nil, OAuth fails with
+    /// "There was an error logging you in." Create a real child WebView built from the
+    /// provided configuration so `window.opener` is preserved and the OAuth callback can
+    /// `postMessage` back to the parent claude.ai page.
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        guard let url = navigationAction.request.url else { return nil }
+
+        // Apply the same allowlist as the parent WebView. OAuth popups must not escape to
+        // arbitrary domains. `about:` URIs are allowed here (handled by decidePolicyFor on
+        // the child's navigationDelegate).
+        if let host = url.host, !isAllowedDomain(host), url.scheme != "about" {
+            logger.info("Blocked popup to disallowed domain: \(host)")
+            return nil
+        }
+
+        // Tear down any previous popup before creating a new one.
+        popupWebView?.stopLoading()
+        popupWebView?.removeFromSuperview()
+
+        let popup = WKWebView(frame: webView.bounds, configuration: configuration)
+        popup.navigationDelegate = self
+        popup.uiDelegate = self
+        popup.customUserAgent = ClaudeAPI.safariUserAgent
+        popup.autoresizingMask = [.width, .height]
+        if #available(macOS 13.3, *) {
+            popup.isInspectable = true  // debug-DMG only
+        }
+        webView.addSubview(popup)
+        self.popupWebView = popup
+
+        logger.debug("Created OAuth popup WebView for: \(url.host ?? url.absoluteString)")
+        return popup
+    }
+
+    /// Called when the OAuth popup's JavaScript executes `window.close()` after the flow
+    /// completes. Tear down the child WebView so the parent login WebView regains focus.
+    func webViewDidClose(_ webView: WKWebView) {
+        if webView === popupWebView {
+            popupWebView?.removeFromSuperview()
+            popupWebView = nil
+            logger.debug("OAuth popup closed itself")
+        }
+    }
+
+    /// Surface JS `alert()` messages as native NSAlert sheets. Without this, claude.ai's
+    /// error messages are silently dropped inside the WebView.
+    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
+        guard let window = loginWindowController?.window else {
+            completionHandler()
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.addButton(withTitle: "OK")
+        alert.beginSheetModal(for: window) { _ in completionHandler() }
+    }
+
+    /// Surface JS `confirm()` prompts as native NSAlert sheets with OK / Cancel.
+    func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+        guard let window = loginWindowController?.window else {
+            completionHandler(false)
+            return
+        }
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        alert.beginSheetModal(for: window) { response in
+            completionHandler(response == .alertFirstButtonReturn)
+        }
+    }
+}
+
+// MARK: - WKScriptMessageHandler (debug-DMG netlog)
+
+extension AuthManager: WKScriptMessageHandler {
+    nonisolated func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == "claudebatteryNetLog" else { return }
+        let body: String
+        if let str = message.body as? String {
+            body = str
+        } else {
+            body = String(describing: message.body)
+        }
+        // `.public` formatting so Release builds emit the literal payload to Console.app,
+        // not the `<private>` placeholder that Logger applies by default.
+        logger.info("NetLog: \(body, privacy: .public)")
     }
 }
 
@@ -498,6 +729,7 @@ extension AuthManager: NSWindowDelegate {
         if loginState == .signingIn {
             hasCapturedSession = false
             pendingSessionKey = nil
+            pendingCookieHeader = nil
         }
         loginState = .idle
 
@@ -507,6 +739,9 @@ extension AuthManager: NSWindowDelegate {
         cookiePollTimer = nil
         urlObservation?.invalidate()
         urlObservation = nil
+        popupWebView?.stopLoading()
+        popupWebView?.removeFromSuperview()
+        popupWebView = nil
         loginWebView?.stopLoading()
         loginWebView?.configuration.websiteDataStore.httpCookieStore.remove(self)
         loginWebView = nil

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -23,6 +23,7 @@ class AuthManager: NSObject, ObservableObject {
     private var loginWindowController: NSWindowController?
     private var loginTimeoutTask: Task<Void, Never>?
     private var orgDiscoveryTask: Task<Void, Never>?
+    private var cookieEnumerationTask: Task<Void, Never>?
     private var cookiePollTimer: Timer?
     private var urlObservation: NSKeyValueObservation?
     private var hasCapturedSession = false
@@ -232,6 +233,10 @@ class AuthManager: NSObject, ObservableObject {
     private func stopLoginWindow() {
         loginTimeoutTask?.cancel()
         loginTimeoutTask = nil
+        cookieEnumerationTask?.cancel()
+        cookieEnumerationTask = nil
+        orgDiscoveryTask?.cancel()
+        orgDiscoveryTask = nil
         cookiePollTimer?.invalidate()
         cookiePollTimer = nil
         urlObservation?.invalidate()
@@ -288,15 +293,17 @@ class AuthManager: NSObject, ObservableObject {
         // Capture loginWebView before the first await so a concurrent stopLoginWindow call
         // that nils the property does not cause us to skip cookie enumeration (COR-002).
         let capturedWebView = self.loginWebView
-        Task { [weak self] in
+        cookieEnumerationTask = Task { [weak self] in
             guard let self else { return }
             if let webView = capturedWebView {
                 let allCookies = await webView.configuration.websiteDataStore.httpCookieStore.allCookies()
+                guard !Task.isCancelled else { return }
                 let claudeCookies = allCookies.filter(Self.isClaudeCookie)
                 let header = claudeCookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
                 self.pendingCookieHeader = header.isEmpty ? nil : header
                 logger.info("Captured \(claudeCookies.count) .claude.ai cookies for API requests")
             }
+            guard !Task.isCancelled else { return }
             self.orgDiscoveryTask = Task { await self.fetchOrganizationId() }
         }
     }
@@ -628,21 +635,20 @@ extension AuthManager: WKUIDelegate {
     func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         guard let url = navigationAction.request.url else { return nil }
 
-        // Apply the same allowlist as the parent WebView. OAuth popups must not escape to
-        // arbitrary domains. Require a host (blocks javascript:, data:, blob: URIs) or
-        // allow about: (handled by decidePolicyFor on the child's navigationDelegate).
-        guard let host = url.host else {
-            if url.scheme == "about" { /* fall through to popup creation */ }
-            else {
-                logger.info("Blocked popup with no host: \(url.scheme ?? "nil")")
+        // Allow about:blank/about:srcdoc (Google OAuth bootstraps popups at about:blank
+        // before navigating to accounts.google.com). For all other URLs, apply the same
+        // domain allowlist as the parent WebView.
+        if url.scheme == "about" {
+            let abs = url.absoluteString
+            guard abs == "about:blank" || abs.hasPrefix("about:blank") || abs.hasPrefix("about:srcdoc") else {
+                logger.info("Blocked popup to unusual about: URI: \(abs)")
                 return nil
             }
-            // about: URIs with no host are allowed — continue to popup creation below
-            return nil // placeholder; about: with no host is uncommon, block conservatively
-        }
-        if !isAllowedDomain(host) {
-            logger.info("Blocked popup to disallowed domain: \(host)")
-            return nil
+        } else {
+            guard let host = url.host, isAllowedDomain(host) else {
+                logger.info("Blocked popup to disallowed domain: \(url.host ?? url.scheme ?? "nil")")
+                return nil
+            }
         }
 
         // Tear down any previous popup before creating a new one.
@@ -707,6 +713,7 @@ extension AuthManager: WKUIDelegate {
 
 // MARK: - WKScriptMessageHandler (debug-DMG netlog)
 
+#if DEBUG
 extension AuthManager: WKScriptMessageHandler {
     nonisolated func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == "claudebatteryNetLog" else { return }
@@ -716,11 +723,10 @@ extension AuthManager: WKScriptMessageHandler {
         } else {
             body = String(describing: message.body)
         }
-        // `.public` formatting so Release builds emit the literal payload to Console.app,
-        // not the `<private>` placeholder that Logger applies by default.
         logger.info("NetLog: \(body, privacy: .public)")
     }
 }
+#endif
 
 // MARK: - WKHTTPCookieStoreObserver
 
@@ -740,10 +746,6 @@ extension AuthManager: WKHTTPCookieStoreObserver {
 
 extension AuthManager: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        // Cancel in-flight org discovery if user closes window
-        orgDiscoveryTask?.cancel()
-        orgDiscoveryTask = nil
-
         // Reset auth state so user can try again
         if loginState == .signingIn {
             hasCapturedSession = false
@@ -752,19 +754,8 @@ extension AuthManager: NSWindowDelegate {
         }
         loginState = .idle
 
-        loginTimeoutTask?.cancel()
-        loginTimeoutTask = nil
-        cookiePollTimer?.invalidate()
-        cookiePollTimer = nil
-        urlObservation?.invalidate()
-        urlObservation = nil
-        popupWebView?.stopLoading()
-        popupWebView?.removeFromSuperview()
-        popupWebView = nil
-        loginWebView?.stopLoading()
-        loginWebView?.configuration.websiteDataStore.httpCookieStore.remove(self)
-        loginWebView = nil
-        loginWindowController = nil
+        // Delegate all resource cleanup to stopLoginWindow (single teardown path)
+        stopLoginWindow()
     }
 }
 

--- a/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
@@ -5,15 +5,26 @@ import Foundation
 enum ClaudeAPI {
     static let baseURL = "https://claude.ai"
 
-    /// Safari version token — the only component that changes between releases. Update when shipping.
+    /// Safari version token - the only component that changes between releases. Update when shipping.
     private static let safariVersionToken = "Version/18.3"
 
     static let safariUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) \(safariVersionToken) Safari/605.1.15"
 
+    /// Cookie jar for API requests. Points at `HTTPCookieStorage.shared` because the custom
+    /// `HTTPCookieStorage()` init returns a placeholder that does not actually retain cookies
+    /// (a long-standing Foundation quirk on macOS). Sharing with the process-wide storage is
+    /// safe in practice: `UpdateChecker.session` explicitly nil's out its cookie storage, and
+    /// WKWebView uses a non-persistent data store at login time, so nothing else writes to the
+    /// shared jar. At account-activation boundaries we call `activateCookies(...)` which wipes
+    /// every claude.ai cookie and re-injects from `Account.allCookieHeader`, preventing stale
+    /// cookies from a prior account or app run from leaking into the next session.
+    private static var cookieStorage: HTTPCookieStorage { .shared }
+
     static let session: URLSession = {
         let config = URLSessionConfiguration.ephemeral
-        config.httpShouldSetCookies = false
-        config.httpCookieStorage = nil
+        config.httpCookieStorage = cookieStorage
+        config.httpShouldSetCookies = true
+        config.httpCookieAcceptPolicy = .always
         config.urlCredentialStorage = nil
         config.waitsForConnectivity = true
         config.timeoutIntervalForRequest = 30
@@ -21,10 +32,76 @@ enum ClaudeAPI {
         return URLSession(configuration: config)
     }()
 
-    static func makeRequest(path: String, sessionKey: String) -> URLRequest? {
+    /// Replace any claude.ai cookies in the per-session jar with the provided cookie set.
+    /// Call at Account-becomes-active moments (app init, account switch, re-auth) so the jar
+    /// reflects the newly-active account's captured cookies. After activation, URLSession
+    /// constructs the `Cookie` header automatically and updates the jar from any `Set-Cookie`
+    /// responses, preserving Cloudflare `__cf_bm` rotation without further intervention.
+    ///
+    /// When `cookieHeader` is nil or empty, the jar is primed with just `sessionKey=<sessionKey>`
+    /// as a fallback - enough for pre-#7-fix accounts on first load, and enough for unit tests
+    /// that do not prime the jar explicitly.
+    static func activateCookies(sessionKey: String, cookieHeader: String?) {
+        clearClaudeCookies()
+        if let cookieHeader, !cookieHeader.isEmpty {
+            injectCookies(from: cookieHeader)
+        } else {
+            injectCookies(from: "sessionKey=\(sessionKey)")
+        }
+    }
+
+    /// Remove every claude.ai-scoped cookie from the per-session jar.
+    /// Used at sign-out and as the first step of `activateCookies`.
+    static func clearClaudeCookies() {
+        cookieStorage.cookies?.forEach { cookie in
+            if cookie.domain == "claude.ai" || cookie.domain == ".claude.ai" || cookie.domain.hasSuffix(".claude.ai") {
+                cookieStorage.deleteCookie(cookie)
+            }
+        }
+    }
+
+    /// Parse a `"name1=value1; name2=value2"` cookie header string and insert each pair as an
+    /// `HTTPCookie` scoped to `.claude.ai`. Synthesizes a `Set-Cookie` line per pair and parses
+    /// it via `HTTPCookie.cookies(withResponseHeaderFields:for:)` - more reliable than the
+    /// properties-dict initializer, which silently returns nil for some valid inputs.
+    /// Caller is responsible for clearing first if a clean slate is required (see
+    /// `activateCookies`).
+    private static func injectCookies(from headerString: String) {
+        guard let url = URL(string: baseURL) else { return }
+        for pair in headerString.components(separatedBy: "; ") {
+            let trimmed = pair.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            let parts = trimmed.split(separator: "=", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            let name = parts[0].trimmingCharacters(in: .whitespaces)
+            let value = parts[1]
+            guard !name.isEmpty, !value.isEmpty else { continue }
+            let setCookieValue = "\(name)=\(value); Domain=.claude.ai; Path=/; Secure"
+            let cookies = HTTPCookie.cookies(withResponseHeaderFields: ["Set-Cookie": setCookieValue], for: url)
+            for cookie in cookies {
+                cookieStorage.setCookie(cookie)
+            }
+        }
+    }
+
+    /// Build a request for a claude.ai endpoint. URLSession constructs the `Cookie` header
+    /// from the per-session jar on dispatch - do not set one explicitly here, since an
+    /// explicit header would suppress the jar's rotation-updated cookies.
+    ///
+    /// `cookieHeader` is an optional escape hatch for callers that want to prime the jar as
+    /// part of the request (e.g., `AuthManager.fetchOrganizationId` right after cookie capture).
+    /// Most production callers (e.g., `UsageService.pollUsage`) should pass `nil` and rely on
+    /// `ClaudeAPI.activateCookies(...)` having been called at the account-activation boundary.
+    static func makeRequest(path: String, sessionKey: String, cookieHeader: String? = nil) -> URLRequest? {
         guard let url = URL(string: "\(baseURL)\(path)") else { return nil }
+
+        if let cookieHeader, !cookieHeader.isEmpty {
+            activateCookies(sessionKey: sessionKey, cookieHeader: cookieHeader)
+        } else if cookieStorage.cookies(for: url)?.contains(where: { $0.name == "sessionKey" }) != true {
+            activateCookies(sessionKey: sessionKey, cookieHeader: nil)
+        }
+
         var request = URLRequest(url: url)
-        request.setValue("sessionKey=\(sessionKey)", forHTTPHeaderField: "Cookie")
         request.setValue("web_claude_ai", forHTTPHeaderField: "anthropic-client-platform")
         request.setValue("1.0.0", forHTTPHeaderField: "anthropic-client-version")
         request.setValue(safariUserAgent, forHTTPHeaderField: "User-Agent")

--- a/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
@@ -68,7 +68,9 @@ enum ClaudeAPI {
     /// `activateCookies`).
     private static func injectCookies(from headerString: String) {
         guard let url = URL(string: baseURL) else { return }
-        for pair in headerString.components(separatedBy: "; ") {
+        // Split on ";" (not "; ") then trim — bare semicolons without trailing space
+        // are valid per RFC 6265 and must not silently drop subsequent cookies.
+        for pair in headerString.components(separatedBy: ";") {
             let trimmed = pair.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty else { continue }
             let parts = trimmed.split(separator: "=", maxSplits: 1).map(String.init)
@@ -95,10 +97,14 @@ enum ClaudeAPI {
     static func makeRequest(path: String, sessionKey: String, cookieHeader: String? = nil) -> URLRequest? {
         guard let url = URL(string: "\(baseURL)\(path)") else { return nil }
 
+        // Prime the jar only when the caller explicitly provides a cookieHeader
+        // (e.g., AuthManager.fetchOrganizationId right after capture). All other
+        // callers rely on activateCookies at account-activation boundaries.
+        // Removed the fallback "jar has no sessionKey → re-prime" branch because
+        // it caused a TOCTOU: concurrent callers could clobber each other's cookies
+        // in the shared HTTPCookieStorage (see ADV-007).
         if let cookieHeader, !cookieHeader.isEmpty {
             activateCookies(sessionKey: sessionKey, cookieHeader: cookieHeader)
-        } else if cookieStorage.cookies(for: url)?.contains(where: { $0.name == "sessionKey" }) != true {
-            activateCookies(sessionKey: sessionKey, cookieHeader: nil)
         }
 
         var request = URLRequest(url: url)

--- a/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/ClaudeAPI.swift
@@ -54,7 +54,7 @@ enum ClaudeAPI {
     /// Used at sign-out and as the first step of `activateCookies`.
     static func clearClaudeCookies() {
         cookieStorage.cookies?.forEach { cookie in
-            if cookie.domain == "claude.ai" || cookie.domain == ".claude.ai" || cookie.domain.hasSuffix(".claude.ai") {
+            if cookie.domain == "claude.ai" || cookie.domain == ".claude.ai" {
                 cookieStorage.deleteCookie(cookie)
             }
         }

--- a/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
@@ -14,8 +14,6 @@ struct Account: Codable, Identifiable, Equatable {
     let addedDate: Date
     var notificationThreshold: Double
     var didNotifyBelowThreshold: Bool
-    /// Optional expiration of the captured sessionKey cookie. Used to trigger proactive re-auth.
-    var sessionKeyExpiration: Date?
     /// Full `.claude.ai` Cookie header captured from the login WebView at login time.
     /// Format: "name1=value1; name2=value2; ...". Primes `ClaudeAPI`'s per-session cookie
     /// jar when this account becomes active, so authenticated API requests carry the
@@ -27,7 +25,7 @@ struct Account: Codable, Identifiable, Equatable {
         nickname ?? email
     }
 
-    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, sessionKeyExpiration: Date? = nil, allCookieHeader: String? = nil) {
+    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, allCookieHeader: String? = nil) {
         self.id = id
         self.email = email
         self.sessionKey = sessionKey
@@ -36,7 +34,6 @@ struct Account: Codable, Identifiable, Equatable {
         self.addedDate = addedDate
         self.notificationThreshold = notificationThreshold
         self.didNotifyBelowThreshold = didNotifyBelowThreshold
-        self.sessionKeyExpiration = sessionKeyExpiration
         self.allCookieHeader = allCookieHeader
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
@@ -14,12 +14,20 @@ struct Account: Codable, Identifiable, Equatable {
     let addedDate: Date
     var notificationThreshold: Double
     var didNotifyBelowThreshold: Bool
+    /// Optional expiration of the captured sessionKey cookie. Used to trigger proactive re-auth.
+    var sessionKeyExpiration: Date?
+    /// Full `.claude.ai` Cookie header captured from the login WebView at login time.
+    /// Format: "name1=value1; name2=value2; ...". Primes `ClaudeAPI`'s per-session cookie
+    /// jar when this account becomes active, so authenticated API requests carry the
+    /// full cookie set (including Cloudflare `__cf_bm`) rather than `sessionKey` alone.
+    /// Nil for accounts migrated from pre-#7-fix builds; those fall back to sessionKey-only.
+    var allCookieHeader: String?
 
     var displayName: String {
         nickname ?? email
     }
 
-    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false) {
+    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, sessionKeyExpiration: Date? = nil, allCookieHeader: String? = nil) {
         self.id = id
         self.email = email
         self.sessionKey = sessionKey
@@ -28,6 +36,8 @@ struct Account: Codable, Identifiable, Equatable {
         self.addedDate = addedDate
         self.notificationThreshold = notificationThreshold
         self.didNotifyBelowThreshold = didNotifyBelowThreshold
+        self.sessionKeyExpiration = sessionKeyExpiration
+        self.allCookieHeader = allCookieHeader
     }
 }
 

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -185,6 +185,8 @@ class UsageService: NSObject, ObservableObject {
                 }
             }
 
+            guard !Task.isCancelled else { return }
+
             latestUsage = UsageData(from: usage, prepaidCredits: prepaidCredits)
             lastSuccessfulFetch = Date()
             consecutiveFailures = 0

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -181,9 +181,7 @@ class UsageService: NSObject, ObservableObject {
                     let creditsBody = String(data: creditsData, encoding: .utf8) ?? "(non-utf8)"
                     logger.info("Prepaid credits response (\(creditsData.count) bytes): \(creditsBody.prefix(500))")
                     #endif
-                    let creditsDecoder = JSONDecoder()
-                    creditsDecoder.keyDecodingStrategy = .convertFromSnakeCase
-                    prepaidCredits = try? creditsDecoder.decode(PrepaidCreditsResponse.self, from: creditsData)
+                    prepaidCredits = try? decoder.decode(PrepaidCreditsResponse.self, from: creditsData)
                 }
             }
 
@@ -356,18 +354,9 @@ struct UsageData {
 // MARK: - Prepaid Credits
 
 /// Raw API response from /api/organizations/{orgId}/prepaid/credits.
-/// Uses lenient decoding — fields may be absent for accounts without prepaid.
+/// Optional fields decode to nil automatically for accounts without prepaid.
 struct PrepaidCreditsResponse: Codable {
     let amount: Double?
-
-    enum CodingKeys: String, CodingKey {
-        case amount
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        amount = try? container.decode(Double.self, forKey: .amount)
-    }
 }
 
 /// Display model for prepaid credit balance. Separate from ExtraUsageData

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -170,7 +170,24 @@ class UsageService: NSObject, ObservableObject {
 
             guard !Task.isCancelled else { return }
 
-            latestUsage = UsageData(from: usage)
+            // Fetch prepaid credit balance (separate endpoint, optional — silently nil if unavailable)
+            var prepaidCredits: PrepaidCreditsResponse?
+            let creditsPath = "/api/organizations/\(account.organizationId)/prepaid/credits"
+            if let creditsRequest = ClaudeAPI.makeRequest(path: creditsPath, sessionKey: account.sessionKey) {
+                if let (creditsData, creditsResponse) = try? await session.data(for: creditsRequest),
+                   let creditsHttp = creditsResponse as? HTTPURLResponse,
+                   (200...299).contains(creditsHttp.statusCode) {
+                    #if DEBUG
+                    let creditsBody = String(data: creditsData, encoding: .utf8) ?? "(non-utf8)"
+                    logger.info("Prepaid credits response (\(creditsData.count) bytes): \(creditsBody.prefix(500))")
+                    #endif
+                    let creditsDecoder = JSONDecoder()
+                    creditsDecoder.keyDecodingStrategy = .convertFromSnakeCase
+                    prepaidCredits = try? creditsDecoder.decode(PrepaidCreditsResponse.self, from: creditsData)
+                }
+            }
+
+            latestUsage = UsageData(from: usage, prepaidCredits: prepaidCredits)
             lastSuccessfulFetch = Date()
             consecutiveFailures = 0
             authFailed = false
@@ -320,8 +337,9 @@ struct UsageData {
     let sonnetRemaining: Double
     let sonnetResetDate: Date?
     let extraUsage: ExtraUsageData?
+    let prepaidBalance: PrepaidBalance?
 
-    init(from response: UsageResponse) {
+    init(from response: UsageResponse, prepaidCredits: PrepaidCreditsResponse? = nil) {
         weeklyRemaining = max(0, min(100, 100 - (response.sevenDay?.utilization ?? 0)))
         weeklyResetDate = response.sevenDay?.resetsAt
         sessionRemaining = max(0, min(100, 100 - (response.fiveHour?.utilization ?? 0)))
@@ -331,5 +349,35 @@ struct UsageData {
         sonnetRemaining = max(0, min(100, 100 - (response.sevenDaySonnet?.utilization ?? 0)))
         sonnetResetDate = response.sevenDaySonnet?.resetsAt
         extraUsage = ExtraUsageData(from: response.extraUsage)
+        prepaidBalance = PrepaidBalance(from: prepaidCredits)
+    }
+}
+
+// MARK: - Prepaid Credits
+
+/// Raw API response from /api/organizations/{orgId}/prepaid/credits.
+/// Uses lenient decoding — fields may be absent for accounts without prepaid.
+struct PrepaidCreditsResponse: Codable {
+    let amount: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case amount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        amount = try? container.decode(Double.self, forKey: .amount)
+    }
+}
+
+/// Display model for prepaid credit balance. Separate from ExtraUsageData
+/// because these are different financial concepts — prepaid is a pre-purchased
+/// balance that depletes, extra usage is pay-as-you-go overage against a cap.
+struct PrepaidBalance {
+    let dollars: Double
+
+    init?(from response: PrepaidCreditsResponse?) {
+        guard let response, let amountCents = response.amount, amountCents > 0 else { return nil }
+        self.dollars = amountCents / 100.0
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -49,6 +49,10 @@ struct UsagePopoverView: View {
                 extraUsageBar(extraUsage: extraUsage)
             }
 
+            if let prepaid = usage.prepaidBalance {
+                prepaidBalanceRow(balance: prepaid)
+            }
+
             LazyVGrid(columns: columns, spacing: 8) {
                 resetsCard(usage: usage)
                 modelsCard(usage: usage)
@@ -214,6 +218,24 @@ struct UsagePopoverView: View {
                 }
             }
             .frame(height: 6)
+        }
+        .padding(10)
+        .background(Color(white: 0.15))
+        .cornerRadius(12)
+    }
+
+    private func prepaidBalanceRow(balance: PrepaidBalance) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Prepaid")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(Color(white: 0.6))
+            Spacer()
+            Text(formatCurrency(balance.dollars))
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundColor(.white)
+            Text(" balance")
+                .font(.system(size: 10, weight: .regular))
+                .foregroundColor(Color(white: 0.45))
         }
         .padding(10)
         .background(Color(white: 0.15))

--- a/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
@@ -146,10 +146,10 @@ final class AuthManagerTests: XCTestCase {
         XCTAssertEqual(auth.loginState, .idle, "Should return to idle after success")
     }
 
-    // MARK: - fetchOrganizationId: Happy Path — multiple orgs uses first
+    // MARK: - fetchOrganizationId: multiple orgs require a window for the picker
 
     @MainActor
-    func testFetchOrganizationId_multipleOrgsUsesFirst() async {
+    func testFetchOrganizationId_multipleOrgsWithNoWindowFailsGracefully() async {
         let auth = makeAuthManager()
 
         let json = """
@@ -163,9 +163,8 @@ final class AuthManagerTests: XCTestCase {
         await auth.fetchOrganizationId()
 
         let store = auth.accountStore
-        XCTAssertEqual(store.accounts.count, 1)
-        XCTAssertEqual(store.accounts.first?.organizationId, "org-first-111",
-                       "Should use the first org's UUID")
+        XCTAssertEqual(store.accounts.count, 0,
+                       "No account is created when the org picker has no window to attach to")
     }
 
     // MARK: - fetchOrganizationId: Error Path — 401 sets error state

--- a/ClaudeBattery/ClaudeBatteryTests/ClaudeAPITests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/ClaudeAPITests.swift
@@ -3,6 +3,17 @@ import XCTest
 
 final class ClaudeAPITests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        // Each test starts with a clean cookie jar so priming behavior is deterministic.
+        ClaudeAPI.clearClaudeCookies()
+    }
+
+    override func tearDown() {
+        ClaudeAPI.clearClaudeCookies()
+        super.tearDown()
+    }
+
     // MARK: - Happy Path: makeRequest returns a valid URLRequest
 
     func testMakeRequestReturnsValidURL() {
@@ -13,11 +24,54 @@ final class ClaudeAPITests: XCTestCase {
         XCTAssertEqual(request?.url?.absoluteString, "https://claude.ai/api/organizations/uuid-123/usage")
     }
 
-    func testMakeRequestSetsCookieHeader() {
+    // MARK: - Cookie jar behavior (primed via makeRequest; URLSession sends from the jar)
+
+    func testMakeRequestWithNilCookieHeaderPrimesJarWithSessionKey() {
         let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk123")
 
-        XCTAssertEqual(request?.value(forHTTPHeaderField: "Cookie"), "sessionKey=sk123")
+        // URLRequest no longer carries an explicit Cookie header - URLSession builds it
+        // from the per-session jar on dispatch so rotating cookies stay fresh.
+        XCTAssertNil(request?.value(forHTTPHeaderField: "Cookie"))
+
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
+        let sessionCookie = cookies.first { $0.name == "sessionKey" }
+        XCTAssertNotNil(sessionCookie, "Jar should contain sessionKey cookie")
+        XCTAssertEqual(sessionCookie?.value, "sk123")
     }
+
+    func testMakeRequestWithEmptyCookieHeaderPrimesJarWithSessionKey() {
+        let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk123", cookieHeader: "")
+
+        XCTAssertNil(request?.value(forHTTPHeaderField: "Cookie"))
+
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
+        let sessionCookie = cookies.first { $0.name == "sessionKey" }
+        XCTAssertNotNil(sessionCookie, "Empty cookieHeader should still fall back to sessionKey priming")
+        XCTAssertEqual(sessionCookie?.value, "sk123")
+    }
+
+    func testMakeRequestWithPopulatedCookieHeaderPrimesJarWithAllCookies() {
+        let header = "sessionKey=sk123; __cf_bm=cf-bm-value; anthropic-csrf-token=csrf-token"
+        let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk123", cookieHeader: header)
+
+        XCTAssertNil(request?.value(forHTTPHeaderField: "Cookie"))
+
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
+        XCTAssertEqual(cookies.first { $0.name == "sessionKey" }?.value, "sk123")
+        XCTAssertEqual(cookies.first { $0.name == "__cf_bm" }?.value, "cf-bm-value")
+        XCTAssertEqual(cookies.first { $0.name == "anthropic-csrf-token" }?.value, "csrf-token")
+    }
+
+    func testMakeRequestEmbedsDifferentSessionKeys() {
+        let key = "sk-ant-sid01-abc123-long-session-key"
+        let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: key)
+
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
+        let sessionCookie = cookies.first { $0.name == "sessionKey" }
+        XCTAssertEqual(sessionCookie?.value, key)
+    }
+
+    // MARK: - Static request headers
 
     func testMakeRequestSetsAnthropicClientPlatform() {
         let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk123")
@@ -55,15 +109,6 @@ final class ClaudeAPITests: XCTestCase {
         XCTAssertEqual(request?.value(forHTTPHeaderField: "referer"), "https://claude.ai/settings/usage")
     }
 
-    // MARK: - Happy Path: sessionKey embedded correctly in Cookie
-
-    func testMakeRequestEmbedsDifferentSessionKeys() {
-        let key = "sk-ant-sid01-abc123-long-session-key"
-        let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: key)
-
-        XCTAssertEqual(request?.value(forHTTPHeaderField: "Cookie"), "sessionKey=\(key)")
-    }
-
     // MARK: - Happy Path: Various paths
 
     func testMakeRequestWithRootPath() {
@@ -80,13 +125,13 @@ final class ClaudeAPITests: XCTestCase {
         XCTAssertEqual(request?.url?.absoluteString, "https://claude.ai")
     }
 
-    // MARK: - All nine expected headers are present
+    // MARK: - All expected URLRequest headers (Cookie lives in the jar, not on the request)
 
-    func testMakeRequestContainsAllNineHeaders() {
+    func testMakeRequestContainsAllEightURLRequestHeaders() {
         let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk1")!
 
+        // Cookie is managed via URLSession's cookie jar (see cookie-jar tests), not set here.
         let expectedHeaders = [
-            "Cookie",
             "anthropic-client-platform",
             "anthropic-client-version",
             "User-Agent",
@@ -102,5 +147,9 @@ final class ClaudeAPITests: XCTestCase {
                 "Missing expected header: \(header)"
             )
         }
+
+        // Explicit Cookie header must NOT be set - URLSession builds it from the jar so
+        // rotating cookies (Cloudflare `__cf_bm`) flow through `Set-Cookie` responses.
+        XCTAssertNil(request.value(forHTTPHeaderField: "Cookie"))
     }
 }

--- a/ClaudeBattery/ClaudeBatteryTests/ClaudeAPITests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/ClaudeAPITests.swift
@@ -152,4 +152,97 @@ final class ClaudeAPITests: XCTestCase {
         // rotating cookies (Cloudflare `__cf_bm`) flow through `Set-Cookie` responses.
         XCTAssertNil(request.value(forHTTPHeaderField: "Cookie"))
     }
+
+    // MARK: - injectCookies edge cases
+
+    func testInjectCookiesSplitsOnBareSemicolon() {
+        // RFC 6265 allows ";" without trailing space between cookie pairs
+        let header = "sessionKey=sk123;__cf_bm=cfvalue"
+        ClaudeAPI.activateCookies(sessionKey: "sk123", cookieHeader: header)
+        let url = URL(string: "https://claude.ai")!
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: url) ?? []
+        XCTAssertNotNil(cookies.first { $0.name == "sessionKey" }, "sessionKey missing after bare-semicolon split")
+        XCTAssertNotNil(cookies.first { $0.name == "__cf_bm" }, "__cf_bm missing after bare-semicolon split")
+    }
+
+    func testInjectCookiesHandlesValueWithEquals() {
+        // Base64-encoded session keys often contain "=" padding
+        let header = "sessionKey=sk-ant-abc123=="
+        ClaudeAPI.activateCookies(sessionKey: "x", cookieHeader: header)
+        let url = URL(string: "https://claude.ai")!
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: url) ?? []
+        let sk = cookies.first { $0.name == "sessionKey" }
+        XCTAssertEqual(sk?.value, "sk-ant-abc123==", "Cookie value with = should be preserved")
+    }
+
+    func testActivateCookiesThenClearClaudeCookies() {
+        ClaudeAPI.activateCookies(sessionKey: "sk-test", cookieHeader: "sessionKey=sk-test; __cf_bm=cf")
+        let url = URL(string: "https://claude.ai")!
+        XCTAssertTrue((ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: url) ?? []).count >= 2)
+
+        ClaudeAPI.clearClaudeCookies()
+        let after = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: url) ?? []
+        XCTAssertTrue(after.isEmpty, "clearClaudeCookies should remove all claude.ai cookies")
+    }
+}
+
+// MARK: - isClaudeCookie / isSessionCookie Tests
+
+@MainActor
+final class CookieDomainValidationTests: XCTestCase {
+
+    func testIsSessionCookie_exactDomain() {
+        let cookie = makeCookie(name: "sessionKey", domain: "claude.ai")
+        XCTAssertTrue(AuthManager.isSessionCookie(cookie))
+    }
+
+    func testIsSessionCookie_leadingDotDomain() {
+        let cookie = makeCookie(name: "sessionKey", domain: ".claude.ai")
+        XCTAssertTrue(AuthManager.isSessionCookie(cookie))
+    }
+
+    func testIsSessionCookie_rejectsEvilDomain() {
+        let cookie = makeCookie(name: "sessionKey", domain: "evil-claude.ai")
+        XCTAssertFalse(AuthManager.isSessionCookie(cookie), "hasSuffix('.claude.ai') must not pass - Critical Pattern #2")
+    }
+
+    func testIsSessionCookie_rejectsWrongName() {
+        let cookie = makeCookie(name: "__cf_bm", domain: "claude.ai")
+        XCTAssertFalse(AuthManager.isSessionCookie(cookie))
+    }
+
+    func testIsClaudeCookie_exactDomain() {
+        let cookie = makeCookie(name: "__cf_bm", domain: "claude.ai")
+        XCTAssertTrue(AuthManager.isClaudeCookie(cookie))
+    }
+
+    func testIsClaudeCookie_leadingDotDomain() {
+        let cookie = makeCookie(name: "__cf_bm", domain: ".claude.ai")
+        XCTAssertTrue(AuthManager.isClaudeCookie(cookie))
+    }
+
+    func testIsClaudeCookie_rejectsEvilDomain() {
+        let cookie = makeCookie(name: "__cf_bm", domain: "evil-claude.ai")
+        XCTAssertFalse(AuthManager.isClaudeCookie(cookie), "hasSuffix must not pass - Critical Pattern #2")
+    }
+
+    func testIsClaudeCookie_rejectsSubdomain() {
+        let cookie = makeCookie(name: "__cf_bm", domain: "cdn.claude.ai")
+        XCTAssertFalse(AuthManager.isClaudeCookie(cookie), "Subdomain cookies should not pass exact-match")
+    }
+
+    func testIsClaudeCookie_rejectsUnrelatedDomain() {
+        let cookie = makeCookie(name: "sessionKey", domain: "google.com")
+        XCTAssertFalse(AuthManager.isClaudeCookie(cookie))
+    }
+
+    private func makeCookie(name: String, domain: String) -> HTTPCookie {
+        HTTPCookie(properties: [
+            .name: name,
+            .value: "test-value",
+            .domain: domain,
+            .path: "/",
+            .secure: "TRUE",
+        ])!
+    }
 }

--- a/ClaudeBattery/ClaudeBatteryTests/ClaudeAPITests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/ClaudeAPITests.swift
@@ -24,30 +24,29 @@ final class ClaudeAPITests: XCTestCase {
         XCTAssertEqual(request?.url?.absoluteString, "https://claude.ai/api/organizations/uuid-123/usage")
     }
 
-    // MARK: - Cookie jar behavior (primed via makeRequest; URLSession sends from the jar)
+    // MARK: - Cookie jar behavior
+    // makeRequest only primes the jar when cookieHeader is explicitly provided.
+    // With nil or empty cookieHeader, callers must prime via activateCookies at
+    // account-activation boundaries (AccountStore.switchTo, etc).
 
-    func testMakeRequestWithNilCookieHeaderPrimesJarWithSessionKey() {
+    func testMakeRequestWithNilCookieHeaderDoesNotPrimeJar() {
         let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk123")
 
-        // URLRequest no longer carries an explicit Cookie header - URLSession builds it
-        // from the per-session jar on dispatch so rotating cookies stay fresh.
         XCTAssertNil(request?.value(forHTTPHeaderField: "Cookie"))
 
         let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
         let sessionCookie = cookies.first { $0.name == "sessionKey" }
-        XCTAssertNotNil(sessionCookie, "Jar should contain sessionKey cookie")
-        XCTAssertEqual(sessionCookie?.value, "sk123")
+        XCTAssertNil(sessionCookie, "Nil cookieHeader must not auto-prime the jar (TOCTOU fix)")
     }
 
-    func testMakeRequestWithEmptyCookieHeaderPrimesJarWithSessionKey() {
+    func testMakeRequestWithEmptyCookieHeaderDoesNotPrimeJar() {
         let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: "sk123", cookieHeader: "")
 
         XCTAssertNil(request?.value(forHTTPHeaderField: "Cookie"))
 
         let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
         let sessionCookie = cookies.first { $0.name == "sessionKey" }
-        XCTAssertNotNil(sessionCookie, "Empty cookieHeader should still fall back to sessionKey priming")
-        XCTAssertEqual(sessionCookie?.value, "sk123")
+        XCTAssertNil(sessionCookie, "Empty cookieHeader must not prime the jar")
     }
 
     func testMakeRequestWithPopulatedCookieHeaderPrimesJarWithAllCookies() {
@@ -62,8 +61,9 @@ final class ClaudeAPITests: XCTestCase {
         XCTAssertEqual(cookies.first { $0.name == "anthropic-csrf-token" }?.value, "csrf-token")
     }
 
-    func testMakeRequestEmbedsDifferentSessionKeys() {
+    func testActivateCookiesThenMakeRequestPreservesJar() {
         let key = "sk-ant-sid01-abc123-long-session-key"
+        ClaudeAPI.activateCookies(sessionKey: key, cookieHeader: nil)
         let request = ClaudeAPI.makeRequest(path: "/api/test", sessionKey: key)
 
         let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []

--- a/ClaudeBattery/ClaudeBatteryTests/Helpers/MockHTTPSession.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/Helpers/MockHTTPSession.swift
@@ -11,6 +11,10 @@ final class MockHTTPSession: HTTPDataFetching, @unchecked Sendable {
     var responseStatusCode: Int = 200
     var responseError: Error?
 
+    /// URL-based response overrides. When a request URL contains a matching key,
+    /// the corresponding (data, statusCode) is returned instead of the default.
+    var urlOverrides: [String: (data: Data, statusCode: Int)] = [:]
+
     // MARK: - Request capture (actor-isolated for async safety)
 
     private let _storage = RequestStorage()
@@ -28,6 +32,21 @@ final class MockHTTPSession: HTTPDataFetching, @unchecked Sendable {
         }
 
         let url = request.url ?? URL(string: "https://claude.ai")!
+
+        // Check URL-based overrides first
+        let urlString = url.absoluteString
+        for (key, override) in urlOverrides {
+            if urlString.contains(key) {
+                let response = HTTPURLResponse(
+                    url: url,
+                    statusCode: override.statusCode,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: nil
+                )!
+                return (override.data, response)
+            }
+        }
+
         let response = HTTPURLResponse(
             url: url,
             statusCode: responseStatusCode,

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -280,10 +280,16 @@ final class UsageServicePollTests: XCTestCase {
         let request = mockSession.lastRequest
         XCTAssertNotNil(request)
         XCTAssertTrue(request!.url!.absoluteString.contains("org-test-123"))
-        XCTAssertEqual(
-            request!.value(forHTTPHeaderField: "Cookie"),
-            "sessionKey=sk-ant-test-key"
-        )
+
+        // Cookie is managed via ClaudeAPI's per-session jar (primed in setUp via
+        // accountStore.addAccount -> ClaudeAPI.activateCookies). URLSession constructs
+        // the Cookie header on dispatch, so URLRequest.Cookie is nil here by design.
+        XCTAssertNil(request!.value(forHTTPHeaderField: "Cookie"))
+
+        let cookies = ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: request!.url!) ?? []
+        let sessionCookie = cookies.first { $0.name == "sessionKey" }
+        XCTAssertNotNil(sessionCookie, "Cookie jar should have been primed with sessionKey on account activation")
+        XCTAssertEqual(sessionCookie?.value, "sk-ant-test-key")
     }
 
     // MARK: - 401 auth failure

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -198,6 +198,79 @@ final class ExtraUsageDataTests: XCTestCase {
     }
 }
 
+// MARK: - PrepaidBalance Tests
+
+final class PrepaidBalanceTests: XCTestCase {
+
+    func testPositiveAmount_convertsCentsToDollars() {
+        let response = makePrepaidResponse(amount: 3750)
+        let balance = PrepaidBalance(from: response)
+        XCTAssertNotNil(balance)
+        XCTAssertEqual(balance!.dollars, 37.50, accuracy: 0.01)
+    }
+
+    func testLargeAmount_convertsCentsToDollars() {
+        let response = makePrepaidResponse(amount: 50000)
+        let balance = PrepaidBalance(from: response)
+        XCTAssertNotNil(balance)
+        XCTAssertEqual(balance!.dollars, 500.00, accuracy: 0.01)
+    }
+
+    func testZeroAmount_returnsNil() {
+        let response = makePrepaidResponse(amount: 0)
+        XCTAssertNil(PrepaidBalance(from: response))
+    }
+
+    func testNegativeAmount_returnsNil() {
+        let response = makePrepaidResponse(amount: -100)
+        XCTAssertNil(PrepaidBalance(from: response))
+    }
+
+    func testNilResponse_returnsNil() {
+        XCTAssertNil(PrepaidBalance(from: nil))
+    }
+
+    func testNilAmount_returnsNil() {
+        let response = makePrepaidResponse(amount: nil)
+        XCTAssertNil(PrepaidBalance(from: response))
+    }
+
+    func testDecodesFromJSON() {
+        let json = """
+        {"amount": 1250}
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try! decoder.decode(PrepaidCreditsResponse.self, from: json)
+        let balance = PrepaidBalance(from: response)
+        XCTAssertNotNil(balance)
+        XCTAssertEqual(balance!.dollars, 12.50, accuracy: 0.01)
+    }
+
+    func testDecodesFromEmptyJSON() {
+        let json = "{}".data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let response = try! decoder.decode(PrepaidCreditsResponse.self, from: json)
+        XCTAssertNil(response.amount)
+        XCTAssertNil(PrepaidBalance(from: response))
+    }
+
+    private func makePrepaidResponse(amount: Double?) -> PrepaidCreditsResponse {
+        if let amount {
+            let json = "{\"amount\": \(amount)}".data(using: .utf8)!
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try! decoder.decode(PrepaidCreditsResponse.self, from: json)
+        } else {
+            let json = "{}".data(using: .utf8)!
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try! decoder.decode(PrepaidCreditsResponse.self, from: json)
+        }
+    }
+}
+
 // MARK: - UsageService.pollUsage() Tests
 
 final class UsageServicePollTests: XCTestCase {

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -207,12 +207,10 @@ final class UsageServicePollTests: XCTestCase {
     private var storage: StorageService!
     private var accountStore: AccountStore!
 
-    /// Shared test account with a valid (far-future) session expiration.
     private let testAccount = Account(
         email: "test@example.com",
         sessionKey: "sk-ant-test-key",
-        organizationId: "org-test-123",
-        sessionKeyExpiration: Date.distantFuture
+        organizationId: "org-test-123"
     )
 
     @MainActor

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -538,6 +538,86 @@ final class UsageServicePollTests: XCTestCase {
         XCTAssertEqual(extra.percentage, 75.0, accuracy: 0.01)
     }
 
+    // MARK: - Prepaid credits integration
+
+    @MainActor
+    func testPoll200WithPrepaidCredits_populatesPrepaidBalance() async {
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        // Override the prepaid credits endpoint to return valid credits
+        mockSession.urlOverrides["prepaid/credits"] = (
+            data: """
+            {"amount": 2500}
+            """.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        await service.pollUsage()
+
+        XCTAssertNotNil(service.latestUsage)
+        let balance = service.latestUsage?.prepaidBalance
+        XCTAssertNotNil(balance,
+                        "Prepaid balance should be populated when credits endpoint returns valid data")
+        if let dollars = balance?.dollars {
+            XCTAssertEqual(dollars, 25.0, accuracy: 0.01,
+                           "2500 cents should convert to $25.00")
+        }
+    }
+
+    @MainActor
+    func testPoll200WithCredits401_prepaidBalanceIsNil() async {
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        // Override credits endpoint to return 401
+        mockSession.urlOverrides["prepaid/credits"] = (
+            data: Data(),
+            statusCode: 401
+        )
+
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        await service.pollUsage()
+
+        XCTAssertNotNil(service.latestUsage)
+        XCTAssertNil(service.latestUsage?.prepaidBalance,
+                     "Prepaid balance should be nil when credits endpoint returns 401")
+        XCTAssertEqual(service.consecutiveFailures, 0,
+                       "Credits 401 should not affect consecutiveFailures")
+    }
+
+    @MainActor
+    func testPoll200WithMalformedCredits_prepaidBalanceIsNil() async {
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        // Override credits endpoint to return malformed JSON
+        mockSession.urlOverrides["prepaid/credits"] = (
+            data: "not json".data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        await service.pollUsage()
+
+        XCTAssertNotNil(service.latestUsage)
+        XCTAssertNil(service.latestUsage?.prepaidBalance,
+                     "Prepaid balance should be nil when credits response is malformed")
+    }
+
     // MARK: - Helpers
 
     private func fixtureData(_ name: String) -> Data {


### PR DESCRIPTION
## Summary

Round 9 sign-in hardening for issue #7, plus prepaid balance display and a crash fix found during integration testing.

**Sign-in fixes:**
- Fix Google OAuth popups: `about:blank` URLs in `createWebViewWith` were silently blocked (dead code returned nil for all host-less URLs). Restructured to check scheme before host so OAuth bootstrap frames work
- Full cookie header capture: all `.claude.ai` cookies (including Cloudflare `__cf_bm`) sent with API requests, not just `sessionKey`
- Dashboard URL detection: delayed cookie re-check when WebView navigates to `/chat`, `/new`, or `/` (SPA login completion)
- OAuth popup WebView support via `WKUIDelegate` for Google "Continue with Google" flow
- Debug network logging via JS injection for diagnosing sign-in failures (gated behind `#if DEBUG`)

**Prepaid balance:**
- Fetch `/api/organizations/{orgId}/prepaid/credits` on each poll cycle
- Display dollar balance in the popover when available

**Crash fix:**
- `windowWillClose` -> `stopLoginWindow()` -> `close()` recursion cycle caused stack overflow when login window closed (e.g. after signing into a second account). Fixed by nilling `loginWindowController` before calling `stopLoginWindow()`

**Code review findings addressed (6-reviewer pass):**
- Unified teardown paths (`windowWillClose` delegates to `stopLoginWindow`)
- Made cookie enumeration Task cancellable
- Gated `WKScriptMessageHandler` behind `#if DEBUG`
- Aligned `clearClaudeCookies` domain check with `isClaudeCookie`
- Added cancellation check after prepaid credits await
- Added URL-based response dispatch to MockHTTPSession + 3 prepaid credits tests

117 tests pass.

## Test plan

- [ ] Sign in with email/code - verify sign-in works and icon appears
- [ ] Sign in with Google OAuth - verify popup appears and completes
- [ ] Sign into second account - verify no crash, icon updates
- [ ] Verify prepaid balance shows in popover (if account has prepaid credits)
- [ ] Close login window mid-sign-in - verify no crash, can retry

Closes #7
May also close #17 (blank sign-in modal - same root cause)