### PR TITLE
Add GoatCounter analytics to website

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -471,6 +471,7 @@
       .footer { padding: 32px 0; }
     }
   </style>
+  <script data-goatcounter="https://claude-battery.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- Add GoatCounter tracking script to `site/index.html` for privacy-friendly pageview analytics on claudebattery.com.
- Endpoint: `https://claude-battery.goatcounter.com/count`.

## Test plan
- [x] Script tag inserted before `</head>` so it loads alongside other head assets
- [ ] After merge, GitHub Pages redeploys; verify a pageview lands in GoatCounter dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)