### PR TITLE
fix: force USD currency code in usage formatter

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -183,6 +183,7 @@ struct UsagePopoverView: View {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.locale = Locale.current
+        formatter.currencyCode = "USD"
         formatter.maximumFractionDigits = 2
         formatter.minimumFractionDigits = 2
         return formatter


### PR DESCRIPTION
## Summary

`UsagePopoverView.currencyFormatter` uses `NumberFormatter` with `.currency` style and `Locale.current`. The API returns values in USD (the `ExtraUsageData.spent` / `PrepaidBalance.dollars` fields are dollars), but with only `Locale.current` set, the formatter substitutes the locale's currency code — so a `ru_RU` user sees `0,74 RUB / 50,00 RUB` instead of `$0.74 / $50.00`. The number itself isn't converted, just relabeled, which is misleading.

This pins `currencyCode = "USD"` so the displayed currency always matches the underlying value, while keeping `Locale.current` so digit grouping and decimal separators stay locale-aware (e.g. `0,74 $` for ru_RU, `$0.74` for en_US).

Affects both `extraUsageBar` and the prepaid balance row — both go through the same formatter.

## Before / after (ru_RU locale)

- Before: `Extra Usage  0,74 RUB / 50,00 RUB`
- After:  `Extra Usage  0,74 $ / 50,00 $`

## Test plan

- [ ] Set system region to a non-USD locale (e.g. Russia / Germany), launch the app, open the popover — Extra Usage and prepaid balance rows show USD.
- [ ] Region = United States — output is unchanged (`$0.74 / $50.00`).