### PR TITLE
feat: unified battery bars and Claude Design preview

### DIFF
--- a/ClaudeBattery/ClaudeBattery.xcodeproj/project.pbxproj
+++ b/ClaudeBattery/ClaudeBattery.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		B8B7E94DFB5BF777D586E1F6 /* IconStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55346AC851D0669ADFB2113D /* IconStyleTests.swift */; };
 		CBCF1234ABCD5678EF901234 /* IconSignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBCF1234ABCD5678EF901235 /* IconSignatureTests.swift */; };
 		E10000010000000000000001 /* UsagePopoverViewCurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000010000000000000001 /* UsagePopoverViewCurrencyTests.swift */; };
+		E10000020000000000000002 /* PrepaidHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20000020000000000000002 /* PrepaidHistoryTests.swift */; };
 		C10000010000000000000001 /* StorageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000010000000000000001 /* StorageServiceTests.swift */; };
 		C10000020000000000000002 /* AccountStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000020000000000000002 /* AccountStoreTests.swift */; };
 		C10000030000000000000003 /* UsageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20000030000000000000003 /* UsageServiceTests.swift */; };
@@ -89,6 +90,7 @@
 		B20000070000000000000007 /* StackedBarsRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedBarsRenderer.swift; sourceTree = "<group>"; };
 		C20000010000000000000001 /* StorageServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StorageServiceTests.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
 		E20000010000000000000001 /* UsagePopoverViewCurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UsagePopoverViewCurrencyTests.swift; path = UsagePopoverViewCurrencyTests.swift; sourceTree = "<group>"; };
+		E20000020000000000000002 /* PrepaidHistoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrepaidHistoryTests.swift; path = PrepaidHistoryTests.swift; sourceTree = "<group>"; };
 		C20000020000000000000002 /* AccountStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccountStoreTests.swift; path = AccountStoreTests.swift; sourceTree = "<group>"; };
 		C20000030000000000000003 /* UsageServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UsageServiceTests.swift; path = UsageServiceTests.swift; sourceTree = "<group>"; };
 		C20000040000000000000004 /* MockHTTPSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockHTTPSession.swift; path = Helpers/MockHTTPSession.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 				C20000020000000000000002 /* AccountStoreTests.swift */,
 				C20000030000000000000003 /* UsageServiceTests.swift */,
 				E20000010000000000000001 /* UsagePopoverViewCurrencyTests.swift */,
+				E20000020000000000000002 /* PrepaidHistoryTests.swift */,
 				C20000040000000000000004 /* MockHTTPSession.swift */,
 				C20000050000000000000005 /* usage_full.json */,
 				C20000060000000000000006 /* usage_nil_fields.json */,
@@ -405,6 +408,7 @@
 				B8B7E94DFB5BF777D586E1F6 /* IconStyleTests.swift in Sources */,
 				CBCF1234ABCD5678EF901234 /* IconSignatureTests.swift in Sources */,
 				E10000010000000000000001 /* UsagePopoverViewCurrencyTests.swift in Sources */,
+				E10000020000000000000002 /* PrepaidHistoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
@@ -50,6 +50,15 @@ final class StorageService {
         static let accounts = "accounts"
         static let activeAccountId = "activeAccountId"
         static let migrated = "migrated"
+        static let prepaidHistoryPrefix = "prepaidHistory."
+    }
+
+    /// One entry per calendar day per account. `date` is the start-of-day boundary
+    /// in the writer's current calendar; `maxDollars` is the highest balance observed
+    /// during that day. Window trimmed to 100 days on every write.
+    struct PrepaidHistoryEntry: Codable, Equatable {
+        let date: Date
+        let maxDollars: Double
     }
 
     init(defaults: UserDefaults = .standard, prefix: String = "cb_") {
@@ -107,6 +116,62 @@ final class StorageService {
         } else {
             defaults.removeObject(forKey: prefix + Keys.activeAccountId)
         }
+    }
+
+    // MARK: - Prepaid Balance History
+
+    /// Records an observed prepaid balance. Coalesces same-day observations to the day's
+    /// max, appends a new entry for a new day, then trims entries older than 100 days.
+    /// `@MainActor` isolated so the read-modify-write does not race when multiple
+    /// accounts poll concurrently.
+    @MainActor
+    func recordPrepaidObservation(accountId: UUID, balance: Double, observedAt: Date = Date()) {
+        guard balance >= 0 else { return }
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: observedAt)
+        guard let cutoff = calendar.date(byAdding: .day, value: -100, to: today) else { return }
+
+        var entries = readPrepaidHistory(accountId: accountId)
+        entries.removeAll { $0.date < cutoff }
+
+        if let lastIdx = entries.indices.last, entries[lastIdx].date == today {
+            if balance > entries[lastIdx].maxDollars {
+                entries[lastIdx] = PrepaidHistoryEntry(date: today, maxDollars: balance)
+            }
+        } else {
+            entries.append(PrepaidHistoryEntry(date: today, maxDollars: balance))
+        }
+
+        writePrepaidHistory(accountId: accountId, entries: entries)
+    }
+
+    /// Returns the highest observed balance within the 100-day window, or nil if no
+    /// observations have been recorded for the account.
+    @MainActor
+    func prepaidHighWaterMark(accountId: UUID) -> Double? {
+        let entries = readPrepaidHistory(accountId: accountId)
+        return entries.map { $0.maxDollars }.max()
+    }
+
+    private func prepaidHistoryStorageKey(accountId: UUID) -> String {
+        prefix + Keys.prepaidHistoryPrefix + accountId.uuidString
+    }
+
+    private func readPrepaidHistory(accountId: UUID) -> [PrepaidHistoryEntry] {
+        guard let data = defaults.data(forKey: prepaidHistoryStorageKey(accountId: accountId)) else { return [] }
+        guard let entries = try? JSONDecoder().decode([PrepaidHistoryEntry].self, from: data) else {
+            logger.error("Failed to decode prepaid history for \(accountId)")
+            return []
+        }
+        return entries
+    }
+
+    private func writePrepaidHistory(accountId: UUID, entries: [PrepaidHistoryEntry]) {
+        guard let data = try? JSONEncoder().encode(entries) else {
+            logger.error("Failed to encode prepaid history for \(accountId)")
+            return
+        }
+        defaults.set(data, forKey: prepaidHistoryStorageKey(accountId: accountId))
     }
 
     // MARK: - Migration

--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -188,7 +188,16 @@ class UsageService: NSObject, ObservableObject {
 
             guard !Task.isCancelled else { return }
 
-            latestUsage = UsageData(from: usage, prepaidCredits: prepaidCredits)
+            // Record the observation for the 100-day high-water-mark window; read back the HWM
+            // so the popover bar has a meaningful "remaining of N" denominator.
+            var prepaidMaximum: Double?
+            if let amountCents = prepaidCredits?.amount, amountCents > 0 {
+                let dollars = amountCents / 100.0
+                storage.recordPrepaidObservation(accountId: account.id, balance: dollars)
+                prepaidMaximum = storage.prepaidHighWaterMark(accountId: account.id)
+            }
+
+            latestUsage = UsageData(from: usage, prepaidCredits: prepaidCredits, prepaidMaximum: prepaidMaximum)
             lastSuccessfulFetch = Date()
             if consecutiveFailures != 0 { consecutiveFailures = 0 }
             if authFailed { authFailed = false }
@@ -340,7 +349,7 @@ struct UsageData: Equatable {
     let extraUsage: ExtraUsageData?
     let prepaidBalance: PrepaidBalance?
 
-    init(from response: UsageResponse, prepaidCredits: PrepaidCreditsResponse? = nil) {
+    init(from response: UsageResponse, prepaidCredits: PrepaidCreditsResponse? = nil, prepaidMaximum: Double? = nil) {
         weeklyRemaining = max(0, min(100, 100 - (response.sevenDay?.utilization ?? 0)))
         weeklyResetDate = response.sevenDay?.resetsAt
         sessionRemaining = max(0, min(100, 100 - (response.fiveHour?.utilization ?? 0)))
@@ -350,7 +359,7 @@ struct UsageData: Equatable {
         sonnetRemaining = max(0, min(100, 100 - (response.sevenDaySonnet?.utilization ?? 0)))
         sonnetResetDate = response.sevenDaySonnet?.resetsAt
         extraUsage = ExtraUsageData(from: response.extraUsage)
-        prepaidBalance = PrepaidBalance(from: prepaidCredits)
+        prepaidBalance = PrepaidBalance(from: prepaidCredits, maximum: prepaidMaximum)
     }
 }
 
@@ -367,9 +376,14 @@ struct PrepaidCreditsResponse: Codable {
 /// balance that depletes, extra usage is pay-as-you-go overage against a cap.
 struct PrepaidBalance: Equatable {
     let dollars: Double
+    /// 100-day rolling high-water-mark of observed balances. Nil before any history is
+    /// recorded for the account; otherwise the maximum of `recordPrepaidObservation`
+    /// inputs in the trailing window. Drives the popover bar's "remaining of N" denominator.
+    let maximum: Double?
 
-    init?(from response: PrepaidCreditsResponse?) {
+    init?(from response: PrepaidCreditsResponse?, maximum: Double? = nil) {
         guard let response, let amountCents = response.amount, amountCents > 0 else { return nil }
         self.dollars = amountCents / 100.0
+        self.maximum = maximum
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -53,6 +53,8 @@ struct UsagePopoverView: View {
                 prepaidBalanceRow(balance: prepaid)
             }
 
+            claudeDesignRow()
+
             LazyVGrid(columns: columns, spacing: 8) {
                 resetsCard(usage: usage)
                 modelsCard(usage: usage)
@@ -179,6 +181,46 @@ struct UsagePopoverView: View {
         return .cyan
     }
 
+    static func batteryColor(remainingPercent: Double) -> Color {
+        let clamped = max(0, min(100, remainingPercent))
+        if clamped < 20 { return .red }
+        if clamped < 50 { return .orange }
+        return .green
+    }
+
+    @ViewBuilder
+    private func unifiedBarRow<Trailing: View>(
+        label: String,
+        remainingPercent: Double?,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(Color(white: 0.6))
+                Spacer()
+                trailing()
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color(white: 0.25))
+                    if let remaining = remainingPercent {
+                        let clamped = max(0, min(100, remaining))
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Self.batteryColor(remainingPercent: clamped))
+                            .frame(width: max(0, geo.size.width * clamped / 100))
+                    }
+                }
+            }
+            .frame(height: 6)
+        }
+        .padding(10)
+        .background(Color(white: 0.15))
+        .cornerRadius(12)
+    }
+
     static func makeUSDCurrencyFormatter(locale: Locale = .current) -> NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
@@ -196,53 +238,54 @@ struct UsagePopoverView: View {
     }
 
     private func extraUsageBar(extraUsage: ExtraUsageData) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Extra Usage")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(Color(white: 0.6))
-                Spacer()
-                HStack(spacing: 0) {
-                    Text(formatCurrency(extraUsage.spent))
-                        .font(.system(size: 11, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white)
-                    Text(" / \(formatCurrency(extraUsage.limit))")
-                        .font(.system(size: 10, weight: .regular))
-                        .foregroundColor(Color(white: 0.45))
-                }
+        let remaining = max(0, extraUsage.limit - extraUsage.spent)
+        let remainingPercent = extraUsage.limit > 0
+            ? max(0, min(100, remaining / extraUsage.limit * 100))
+            : 0
+
+        return unifiedBarRow(label: "Extra Usage", remainingPercent: remainingPercent) {
+            HStack(spacing: 0) {
+                Text(formatCurrency(remaining))
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                Text(" remaining of \(formatCurrency(extraUsage.limit))")
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundColor(Color(white: 0.45))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
-            GeometryReader { geo in
-                ZStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(Color(white: 0.25))
-                    RoundedRectangle(cornerRadius: 3)
-                        .fill(spendColor(for: extraUsage.percentage))
-                        .frame(width: max(0, geo.size.width * extraUsage.percentage / 100))
-                }
-            }
-            .frame(height: 6)
         }
-        .padding(10)
-        .background(Color(white: 0.15))
-        .cornerRadius(12)
     }
 
-    private func prepaidBalanceRow(balance: PrepaidBalance) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text("Prepaid")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(Color(white: 0.6))
-            Spacer()
-            Text(formatCurrency(balance.dollars))
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
-                .foregroundColor(.white)
-            Text(" balance")
+    private func claudeDesignRow() -> some View {
+        unifiedBarRow(label: "Claude Design", remainingPercent: nil) {
+            Text("Coming soon")
                 .font(.system(size: 10, weight: .regular))
                 .foregroundColor(Color(white: 0.45))
         }
-        .padding(10)
-        .background(Color(white: 0.15))
-        .cornerRadius(12)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Claude Design, coming soon, no usage data yet")
+        .accessibilityHint("Claude Design usage will appear here when Anthropic exposes the API")
+    }
+
+    private func prepaidBalanceRow(balance: PrepaidBalance) -> some View {
+        let maximum = balance.maximum ?? balance.dollars
+        let remainingPercent = maximum > 0
+            ? max(0, min(100, balance.dollars / maximum * 100))
+            : 100
+
+        return unifiedBarRow(label: "Prepaid", remainingPercent: remainingPercent) {
+            HStack(spacing: 0) {
+                Text(formatCurrency(balance.dollars))
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                Text(" remaining of \(formatCurrency(maximum))")
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundColor(Color(white: 0.45))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
     }
 
     // MARK: - States

--- a/ClaudeBattery/ClaudeBatteryTests/PrepaidHistoryTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/PrepaidHistoryTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import ClaudeBattery
+
+@MainActor
+final class PrepaidHistoryTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private let accountId = UUID()
+    private let calendar = Calendar.current
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test.PrepaidHistory.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeStorage() -> StorageService {
+        StorageService(defaults: defaults, prefix: "cb_test_")
+    }
+
+    private func date(daysAgo: Int) -> Date {
+        let now = calendar.startOfDay(for: Date())
+        return calendar.date(byAdding: .day, value: -daysAgo, to: now)!
+    }
+
+    // MARK: - Empty State
+
+    func testHighWaterMark_emptyHistory_returnsNil() {
+        let storage = makeStorage()
+        XCTAssertNil(storage.prepaidHighWaterMark(accountId: accountId))
+    }
+
+    // MARK: - Happy Path: Multi-Day Window
+
+    func testRecordThreeConsecutiveDays_returnsMaxAcrossWindow() {
+        let storage = makeStorage()
+        storage.recordPrepaidObservation(accountId: accountId, balance: 150, observedAt: date(daysAgo: 2))
+        storage.recordPrepaidObservation(accountId: accountId, balance: 300, observedAt: date(daysAgo: 1))
+        storage.recordPrepaidObservation(accountId: accountId, balance: 250, observedAt: date(daysAgo: 0))
+
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountId) ?? .nan, 300, accuracy: 0.001)
+    }
+
+    // MARK: - Same-Day Coalescing
+
+    func testSameDayObservation_keepsHigherValue() {
+        let storage = makeStorage()
+        let today = Date()
+        storage.recordPrepaidObservation(accountId: accountId, balance: 200, observedAt: today)
+        storage.recordPrepaidObservation(accountId: accountId, balance: 180, observedAt: today)
+
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountId) ?? .nan, 200, accuracy: 0.001)
+    }
+
+    func testSameDayObservation_raisesIfHigher() {
+        let storage = makeStorage()
+        let today = Date()
+        storage.recordPrepaidObservation(accountId: accountId, balance: 100, observedAt: today)
+        storage.recordPrepaidObservation(accountId: accountId, balance: 250, observedAt: today)
+
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountId) ?? .nan, 250, accuracy: 0.001)
+    }
+
+    // MARK: - 100-Day Window Trimming
+
+    func testEntriesOlderThan100Days_areTrimmedOnNextWrite() {
+        let storage = makeStorage()
+        storage.recordPrepaidObservation(accountId: accountId, balance: 999, observedAt: date(daysAgo: 200))
+        storage.recordPrepaidObservation(accountId: accountId, balance: 50, observedAt: date(daysAgo: 0))
+
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountId) ?? .nan, 50, accuracy: 0.001)
+    }
+
+    func testEntryAt99Days_isRetained() {
+        let storage = makeStorage()
+        storage.recordPrepaidObservation(accountId: accountId, balance: 500, observedAt: date(daysAgo: 99))
+        storage.recordPrepaidObservation(accountId: accountId, balance: 100, observedAt: date(daysAgo: 0))
+
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountId) ?? .nan, 500, accuracy: 0.001)
+    }
+
+    // MARK: - Account Isolation
+
+    func testTwoAccounts_doNotShareHistory() {
+        let storage = makeStorage()
+        let accountA = UUID()
+        let accountB = UUID()
+
+        storage.recordPrepaidObservation(accountId: accountA, balance: 100, observedAt: Date())
+        storage.recordPrepaidObservation(accountId: accountB, balance: 500, observedAt: Date())
+
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountA) ?? .nan, 100, accuracy: 0.001)
+        XCTAssertEqual(storage.prepaidHighWaterMark(accountId: accountB) ?? .nan, 500, accuracy: 0.001)
+    }
+
+    // MARK: - Persistence Round-Trip
+
+    func testPersistence_survivesStorageReinit() {
+        do {
+            let storage = makeStorage()
+            storage.recordPrepaidObservation(accountId: accountId, balance: 425, observedAt: Date())
+        }
+
+        let storage2 = makeStorage()
+        XCTAssertEqual(storage2.prepaidHighWaterMark(accountId: accountId) ?? .nan, 425, accuracy: 0.001)
+    }
+
+    // MARK: - Negative Balance Guard
+
+    func testNegativeBalance_isIgnored() {
+        let storage = makeStorage()
+        storage.recordPrepaidObservation(accountId: accountId, balance: -50, observedAt: Date())
+        XCTAssertNil(storage.prepaidHighWaterMark(accountId: accountId))
+    }
+}

--- a/ClaudeBattery/ClaudeBatteryTests/UsagePopoverViewCurrencyTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsagePopoverViewCurrencyTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftUI
 @testable import ClaudeBattery
 
 final class UsagePopoverViewCurrencyTests: XCTestCase {
@@ -21,5 +22,33 @@ final class UsagePopoverViewCurrencyTests: XCTestCase {
             formatted.contains("\u{20BD}"),
             "Expected no ruble symbol under ru_RU locale, got `\(formatted)`"
         )
+    }
+}
+
+final class UsagePopoverViewBatteryColorTests: XCTestCase {
+    func testHighRemainingIsGreen() {
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 75), .green)
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 100), .green)
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 50), .green)
+    }
+
+    func testMidRemainingIsOrange() {
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 30), .orange)
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 20), .orange)
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 49), .orange)
+    }
+
+    func testLowRemainingIsRed() {
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 5), .red)
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 0), .red)
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 19.9), .red)
+    }
+
+    func testNegativeRemainingClampsToRed() {
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: -5), .red)
+    }
+
+    func testOverflowRemainingClampsToGreen() {
+        XCTAssertEqual(UsagePopoverView.batteryColor(remainingPercent: 150), .green)
     }
 }

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -595,6 +595,83 @@ final class UsageServicePollTests: XCTestCase {
     }
 
     @MainActor
+    func testPoll200WithPrepaidCredits_setsMaximumToObservedBalanceOnFirstPoll() async {
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        mockSession.urlOverrides["prepaid/credits"] = (
+            data: """
+            {"amount": 20000}
+            """.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        await service.pollUsage()
+
+        let balance = service.latestUsage?.prepaidBalance
+        XCTAssertNotNil(balance)
+        XCTAssertEqual(balance?.dollars ?? .nan, 200.0, accuracy: 0.01)
+        XCTAssertEqual(balance?.maximum ?? .nan, 200.0, accuracy: 0.01,
+                       "On first observation, maximum equals current balance")
+    }
+
+    @MainActor
+    func testPoll200WithPrepaidCredits_carriesPriorMaximumWhenBalanceDrops() async {
+        let activeId = accountStore.activeAccount!.id
+        storage.recordPrepaidObservation(accountId: activeId, balance: 300.0)
+
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        mockSession.urlOverrides["prepaid/credits"] = (
+            data: """
+            {"amount": 18000}
+            """.data(using: .utf8)!,
+            statusCode: 200
+        )
+
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        await service.pollUsage()
+
+        let balance = service.latestUsage?.prepaidBalance
+        XCTAssertEqual(balance?.dollars ?? .nan, 180.0, accuracy: 0.01)
+        XCTAssertEqual(balance?.maximum ?? .nan, 300.0, accuracy: 0.01,
+                       "Maximum should hold at prior HWM when current balance is lower")
+    }
+
+    @MainActor
+    func testPoll200WithCredits401_doesNotRecordPrepaidObservation() async {
+        let activeId = accountStore.activeAccount!.id
+
+        mockSession.responseData = fixtureData("usage_full")
+        mockSession.responseStatusCode = 200
+        mockSession.urlOverrides["prepaid/credits"] = (
+            data: Data(),
+            statusCode: 401
+        )
+
+        let service = UsageService(
+            storage: storage,
+            accountStore: accountStore,
+            session: mockSession
+        )
+
+        await service.pollUsage()
+
+        XCTAssertNil(storage.prepaidHighWaterMark(accountId: activeId),
+                     "401 on prepaid endpoint must not write history")
+    }
+
+    @MainActor
     func testPoll200WithMalformedCredits_prepaidBalanceIsNil() async {
         mockSession.responseData = fixtureData("usage_full")
         mockSession.responseStatusCode = 200


### PR DESCRIPTION
## Summary

Restyles the popover's Extra Usage and Prepaid rows as battery-direction progress bars sharing one color helper (green at full, red near depletion) and one bar primitive. Adds a third "Claude Design" placeholder row with an empty track and "Coming soon" text.

## What changed

- **Battery-color helper**: `batteryColor(remainingPercent:)` returns green / orange / red at 50% / 20% thresholds. Mirrors the existing arc-gauge thresholds so the popover stays color-consistent.
- **Unified bar primitive**: `unifiedBarRow(label:remainingPercent:trailing:)` factors out the label-left / trailing-right / fill-bar-below / card-chrome layout. Three rows now share one source of truth.
- **Extra Usage**: bar depletes left-to-right as spend approaches the limit. Right-side text reads `\$X remaining of \$Y`.
- **Prepaid history layer**: per-account 100-day rolling high-water-mark in UserDefaults, coalesced to one entry per day. Adds `StorageService.recordPrepaidObservation(accountId:balance:observedAt:)` and `StorageService.prepaidHighWaterMark(accountId:)`, both `@MainActor`-isolated against multi-account polling races.
- **Prepaid bar**: fed by the HWM; text reads `\$X remaining of \$Y` where Y is the max observed in the window. On first observation Y equals X (bar at 100%); on top-up the bar snaps to full; on the 100-day cliff Y drops and the bar snaps upward.
- **Claude Design row**: empty track with "Coming soon" trailing text. VoiceOver label set explicitly so screen readers do not announce it as an indeterminate progress widget.

## Tests

173 passing (155 baseline + 18 new):
- 9 PrepaidHistory storage scenarios (empty, multi-day, same-day coalesce, 100-day window trimming, account isolation, persistence, negative-balance guard)
- 5 batteryColor mappings (high / mid / low / clamped negative / clamped overflow)
- 3 UsageService prepaid integration (first-observation max, prior-max-when-balance-drops, 401-does-not-record)
- 1 ru_RU currency formatter regression locked from the prior commit

## Verification

Manual visual gate runs in v1.48 release as U13 (locale screenshots under en_US, ru_RU, de_DE plus a light-mode contrast spot-check).

## Post-Deploy Monitoring & Validation

No runtime monitoring beyond local visual verification. The popover bars are deterministic from UsageService poll output and UserDefaults. Failure mode is a wrong-looking bar in the popover, which the user observes directly. No analytics, no logs, no server-side surface to watch.

If the bars render incorrectly after merge, revert this PR and v1.47 is restored. UserDefaults entries written by this branch are namespaced under `cb_prepaidHistory.<uuid>` and harmless on rollback (the v1.47 code does not read them).

$(~/.claude/hooks/signoff.sh "Opus 4.7")