### PR TITLE
fix(windows): blank login window - replay navigation lost to async WebView2 init

### DIFF
--- a/windows/src/ClaudeBatteryWin/ClaudeBatteryWin.csproj
+++ b/windows/src/ClaudeBatteryWin/ClaudeBatteryWin.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>ClaudeBatteryWin</AssemblyName>
     <!-- Single source of truth for the release version (mirrors the Mac MARKETING_VERSION). pack.ps1
          reads <Version> from here in its no-arg form (U17/#4); bump it per release. -->
-    <Version>1.50.0</Version>
+    <Version>1.50.1</Version>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/windows/src/ClaudeBatteryWin/Views/LoginWindow.xaml.cs
+++ b/windows/src/ClaudeBatteryWin/Views/LoginWindow.xaml.cs
@@ -46,6 +46,11 @@ public partial class LoginWindow : Window, ILoginWebView
     private readonly string _userDataFolder;
     private readonly DispatcherTimer _cookiePollTimer;
 
+    // Bridges a Navigate() call issued before CoreWebView2 exists (PresentLogin navigates synchronously
+    // right after Create(), while init is still async) to the init success path that replays it. Without
+    // it the first navigation is silently dropped and the window stays blank at about:blank.
+    private readonly PendingNavigation _pendingNavigation = new();
+
     private CoreWebView2Environment? _environment;
     private Microsoft.Web.WebView2.Wpf.WebView2? _popup;
     private Func<string, bool>? _popupGate;
@@ -216,6 +221,15 @@ public partial class LoginWindow : Window, ILoginWebView
             core.NavigationCompleted += OnCoreNavigationCompleted;
             core.HistoryChanged += OnCoreHistoryChanged;
             core.NewWindowRequested += OnCoreNewWindowRequested;
+
+            // Replay any navigation requested before the core was ready - the PresentLogin initial load
+            // (and any Retry issued during init). Routed through core.Navigate so it still passes the
+            // NavigationStarting gate. Without this the first navigation is lost and the window stays
+            // blank at about:blank (the field bug: blank "Sign in to Claude" window, zero network).
+            if (_pendingNavigation.TryConsume(out var pendingUrl))
+            {
+                core.Navigate(pendingUrl);
+            }
         }
         catch (Exception ex)
         {
@@ -246,7 +260,21 @@ public partial class LoginWindow : Window, ILoginWebView
 
     public void StartCookiePolling() => _cookiePollTimer.Start();
 
-    public void Navigate(string url) => WebView.CoreWebView2?.Navigate(url);
+    public void Navigate(string url)
+    {
+        // The core initializes asynchronously (InitializeWebView2Async), and AuthManager.PresentLogin
+        // calls Navigate synchronously right after Create() - so on the first call CoreWebView2 is null
+        // and a direct Navigate would be silently dropped, leaving the window blank at about:blank.
+        // Latch the URL when the core is not ready; the init success path replays it. When the core is
+        // already up (e.g. the Retry path after a completed init), navigate immediately.
+        if (WebView.CoreWebView2 is { } core)
+        {
+            core.Navigate(url);
+            return;
+        }
+
+        _pendingNavigation.Set(url);
+    }
 
     void ILoginWebView.Show() => Show();
 

--- a/windows/src/ClaudeBatteryWin/Views/PendingNavigation.cs
+++ b/windows/src/ClaudeBatteryWin/Views/PendingNavigation.cs
@@ -1,0 +1,52 @@
+namespace ClaudeBatteryWin.Views;
+
+/// <summary>
+/// A one-slot navigation latch that bridges the gap between an <c>ILoginWebView.Navigate</c> call and
+/// the asynchronous arrival of <c>CoreWebView2</c>.
+///
+/// <para>
+/// The login flow issues <c>Navigate("https://claude.ai/login")</c> synchronously, on the UI thread,
+/// immediately after the window is created (<c>AuthManager.PresentLogin</c>). But the WebView2 core
+/// initializes asynchronously (<c>LoginWindow.InitializeWebView2Async</c>: <c>Task.Yield</c> →
+/// <c>CreateAsync</c> → <c>EnsureCoreWebView2Async</c>), and those continuations cannot run until the
+/// synchronous <c>PresentLogin</c> body yields the UI thread. So at <c>Navigate</c> time
+/// <c>CoreWebView2</c> is deterministically null, and a direct <c>CoreWebView2?.Navigate</c> is a
+/// silent no-op. Without this latch the very first navigation is dropped and the window stays blank at
+/// <c>about:blank</c> forever - the field bug: a blank "Sign in to Claude" window with zero network
+/// activity, no UA/cookie capture, and no error surface (init succeeded, it just never navigated).
+/// </para>
+///
+/// <para>
+/// <c>Navigate</c> calls <see cref="Set"/> when the core is not ready; the init success path calls
+/// <see cref="TryConsume"/> once the core comes up and replays the URL. The latest write wins (a Retry
+/// issued before init supersedes the initial load), and the slot is cleared on consume so a navigation
+/// is never replayed twice. Not thread-safe by design: every caller runs on the WPF UI thread.
+/// </para>
+/// </summary>
+internal sealed class PendingNavigation
+{
+    private string? _url;
+
+    /// <summary>Whether a URL is currently latched awaiting replay.</summary>
+    public bool HasPending => _url is not null;
+
+    /// <summary>Latch a URL to replay once the core is ready. The latest call wins.</summary>
+    public void Set(string url) => _url = url;
+
+    /// <summary>
+    /// Hand back the latched URL exactly once and clear the slot. Returns false (and an empty string)
+    /// when nothing is pending, so the caller does not navigate spuriously.
+    /// </summary>
+    public bool TryConsume(out string url)
+    {
+        if (_url is { } pending)
+        {
+            _url = null;
+            url = pending;
+            return true;
+        }
+
+        url = string.Empty;
+        return false;
+    }
+}

--- a/windows/tests/ClaudeBatteryWin.Tests/PendingNavigationTests.cs
+++ b/windows/tests/ClaudeBatteryWin.Tests/PendingNavigationTests.cs
@@ -1,0 +1,71 @@
+using ClaudeBatteryWin.Views;
+using Xunit;
+
+namespace ClaudeBatteryWin.Tests;
+
+/// <summary>
+/// Regression tests for the login-window navigation latch (<see cref="PendingNavigation"/>). This is
+/// the unit-testable core of the field bug where the "Sign in to Claude" window stayed blank at
+/// about:blank: AuthManager.PresentLogin navigates synchronously right after the window is created,
+/// but the WebView2 core initializes asynchronously, so the first Navigate landed on a null core and
+/// was silently dropped. LoginWindow.Navigate now latches the URL here when the core is not ready, and
+/// the init success path replays it via <see cref="PendingNavigation.TryConsume"/>.
+///
+/// The real LoginWindow is a WPF + WebView2 surface that needs an STA UI thread and the runtime, so -
+/// exactly like WebView2Runtime backing RuntimeMissingWindow - the load-bearing logic is extracted
+/// here and tested directly with no GUI.
+/// </summary>
+public class PendingNavigationTests
+{
+    [Fact]
+    public void TryConsume_WithNothingLatched_ReturnsFalseAndDoesNotNavigate()
+    {
+        var nav = new PendingNavigation();
+
+        Assert.False(nav.HasPending);
+        Assert.False(nav.TryConsume(out var url));
+        Assert.Equal(string.Empty, url);
+    }
+
+    [Fact]
+    public void SetThenTryConsume_ReplaysTheLatchedUrlOnce()
+    {
+        // The bug: a navigation requested before the core is ready must not be lost. Set models
+        // LoginWindow.Navigate latching the URL; TryConsume models the init success path replaying it.
+        var nav = new PendingNavigation();
+
+        nav.Set("https://claude.ai/login");
+
+        Assert.True(nav.HasPending);
+        Assert.True(nav.TryConsume(out var url));
+        Assert.Equal("https://claude.ai/login", url);
+    }
+
+    [Fact]
+    public void TryConsume_ClearsTheSlot_SoANavigationIsNeverReplayedTwice()
+    {
+        // A second init-success replay (or any second consume) must not re-fire a stale navigation.
+        var nav = new PendingNavigation();
+        nav.Set("https://claude.ai/login");
+
+        Assert.True(nav.TryConsume(out _));
+
+        Assert.False(nav.HasPending);
+        Assert.False(nav.TryConsume(out var second));
+        Assert.Equal(string.Empty, second);
+    }
+
+    [Fact]
+    public void Set_LatestWriteWins()
+    {
+        // A Retry issued while init is still in flight supersedes the initial load: only the most
+        // recent latched URL should replay when the core comes up.
+        var nav = new PendingNavigation();
+
+        nav.Set("https://claude.ai/login");
+        nav.Set("https://claude.ai/login?retry");
+
+        Assert.True(nav.TryConsume(out var url));
+        Assert.Equal("https://claude.ai/login?retry", url);
+    }
+}


### PR DESCRIPTION
## What

First Windows tester (#28) hit a permanently blank "Sign in to Claude" window: WebView2 came up (DevTools attached, InPrivate) but never navigated - stuck at about:blank with zero network requests.

## Root cause

`AuthManager.PresentLogin` navigates synchronously immediately after creating `LoginWindow`, but the window initializes `CoreWebView2` asynchronously (`Task.Yield` -> `CreateAsync` -> `EnsureCoreWebView2Async`). At `Navigate()` time `CoreWebView2` is **deterministically** null, so the old `WebView.CoreWebView2?.Navigate(url)` silently no-opped and nothing replayed it. Deterministic, not a flaky race - which matches the tester seeing it on the first try.

The U2 auth spike worked only because it navigated *after* `EnsureCoreWebView2Async`. The production refactor split init from navigation across the async boundary and dropped that ordering.

## Fix

- `PendingNavigation` (new): a one-slot latch. `LoginWindow.Navigate` stores the URL when the core is not ready, else navigates immediately (preserves the already-initialized Retry path).
- The `InitializeWebView2Async` success path replays the latched URL via `core.Navigate`, so it still passes the `NavigationStarting` allowlist gate.

## Why it shipped green

`LoginWindow` is WPF + WebView2 and has no unit coverage - every `AuthManager` test uses a fake `ILoginWebView` that navigates synchronously. The regression is now locked by `PendingNavigationTests` on the extracted latch (same testability pattern as `WebView2Runtime` backing `RuntimeMissingWindow`).

## Verification

Cannot build/test on macOS (WPF SDK is Windows-only). Relying on Windows CI here, plus a `1.50.1` test pre-release for the reporter to re-run. Bumps version to 1.50.1.

Refs #28.

Co-Authored-By: Derek Zoolander (Claude Opus 4.8 (1M context)) <noreply@anthropic.com>