### PR TITLE
fix(redaction): scrub free-text sk-ant- tokens in diagnostics export

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Services/SecretRedactor.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/SecretRedactor.swift
@@ -331,6 +331,18 @@ enum SecretRedactor {
         options: []
     )
 
+    /// Anthropic session/API tokens carry the unambiguous `sk-ant-` prefix. In production these are
+    /// only ever emitted UNDER a credential key (redacted by `redactCredentialPairs`), but a future
+    /// producer could interpolate one into a free-text field — e.g. a `login-state` error message —
+    /// with no `key=`/`:` delimiter, where none of the structured passes fire. This last-resort pass
+    /// scrubs the token wherever it appears; the `sk-ant-` prefix is distinctive enough that matching
+    /// it anywhere carries no realistic over-redaction risk. (Caught by the NoSecretsExportGate
+    /// login-state sentinel case.)
+    private static let apiTokenRegex = try! NSRegularExpression(
+        pattern: "sk-ant-[A-Za-z0-9_\\-]{1,512}",
+        options: []
+    )
+
     /// Cookie-header keys whose values are redacted by `redactCookieHeader`. Three of these
     /// (`__cf_bm`, `anthropic-csrf-token`, `sessionkey`) are ALSO in `credentialKeys` and already
     /// redacted by the earlier `redactCredentialPairs` pass; the overlap is intentional, not dead.
@@ -405,6 +417,13 @@ enum SecretRedactor {
         //    surviving every structured pass is still caught (defense in depth).
         if hasAt {
             result = redactEmails(result)
+        }
+
+        // 7. Anthropic sk-ant- tokens anywhere — last-resort backstop for a token that reached a
+        //    free-text field under no credential key (e.g. interpolated into an error message) and
+        //    so was never matched by the structured key=value passes.
+        if result.contains("sk-ant-") {
+            result = redactAPITokens(result)
         }
 
         return result
@@ -487,6 +506,18 @@ enum SecretRedactor {
         var replaced = input
         for match in matches.reversed() {
             replaced = (replaced as NSString).replacingCharacters(in: match.range, with: "[EMAIL]")
+        }
+        return replaced
+    }
+
+    private static func redactAPITokens(_ input: String) -> String {
+        let nsString = input as NSString
+        let matches = apiTokenRegex.matches(in: input, range: NSRange(location: 0, length: nsString.length))
+        guard !matches.isEmpty else { return input }
+        var replaced = input
+        for match in matches.reversed() {
+            let token = nsString.substring(with: match.range)
+            replaced = (replaced as NSString).replacingCharacters(in: match.range, with: "REDACTED_LEN_\(token.count)")
         }
         return replaced
     }

--- a/ClaudeBattery/ClaudeBatteryTests/NoSecretsExportGateTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/NoSecretsExportGateTests.swift
@@ -147,5 +147,44 @@ final class NoSecretsExportGateTests: XCTestCase {
         XCTAssertTrue(combined.contains("claude.ai"), "cookie domain signal lost: \(combined)")
     }
 
+    /// Plant the REAL `login-state` producer shape (the U5 adversarial-pass gate blind spot).
+    /// `AuthManager.updateLoginOverlay` interpolates the LoginState `.error` message into
+    /// `payload["state"] = "error: \(message)"` and emits `kind: "login-state"`. Today every `.error`
+    /// message is a static literal so nothing leaks — but the gate never planted this kind, so a future
+    /// error path interpolating a secret (an org name, an API body, `error.localizedDescription`) would
+    /// ship unredacted with a green suite. This pins the contract: a secret-shaped value in a
+    /// login-state error is scrubbed by the unconditional producer→redactor→archive pipeline, which
+    /// applies `SecretRedactor.redact` to every kind with no kind-based branch.
+    func testEndToEnd_loginStateError_hasNoSecrets() throws {
+        let logger = DiagnosticsLogger(directoryOverride: dir, enabledOverride: true)
+        logger.emitMilestone(kind: "login-state", payload: [
+            "state": "error: sign-in failed for victim@example.com (token sk-ant-LOGINSTATESECRET)"
+        ])
+        logger.flush()
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let eligible = LogsExporter.eligibleLogFiles(in: dir, installedAfter: Date(timeIntervalSince1970: 0))
+        let archiveURL = try LogsExporter.buildArchive(from: eligible)
+        defer { try? FileManager.default.removeItem(at: archiveURL) }
+        let extractDir = dir.appendingPathComponent("extracted-loginstate", isDirectory: true)
+        try ArchiveTestSupport.decode(at: archiveURL, into: extractDir)
+
+        var combined = ""
+        for f in try FileManager.default.contentsOfDirectory(at: extractDir, includingPropertiesForKeys: nil) {
+            combined += (try? String(contentsOf: f, encoding: .utf8)) ?? ""
+        }
+        XCTAssertFalse(combined.contains("sk-ant-LOGINSTATESECRET"),
+                       "login-state error token leaked into archive: \(combined)")
+        XCTAssertFalse(combined.contains("victim@example.com"),
+                       "login-state error email leaked into archive: \(combined)")
+        XCTAssertNil(combined.range(of: "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}", options: .regularExpression),
+                     "an @-email survived from the login-state line: \(combined)")
+        XCTAssertTrue(combined.contains("REDACTED_LEN_"),
+                      "expected redaction marker proving the login-state line was processed")
+        // The non-secret signal — the `login-state` kind — must survive so the diagnostic stays useful.
+        XCTAssertTrue(combined.contains("login-state"),
+                      "login-state kind signal lost: \(combined)")
+    }
+
     // MARK: - Helpers (archive decode is shared via ArchiveTestSupport in LogsExporterTests)
 }


### PR DESCRIPTION
## What

Ports a free-text `sk-ant-` redaction backstop to `SecretRedactor`, salvaged from the retired `rc/dry-run-2026-06-16` (v1.49-RC) branch before that branch is deleted. Cherry-pick of `5e709ed`.

## Why

v1.50 ships the **Export Diagnostic Logs** button. On `main`, `SecretRedactor` scrubs `sk-ant-` tokens only when they appear **under a credential key** (`sessionKey=`, `{"token":[...]}`, cookie headers, etc.). A bare `sk-ant-` token sitting in a **free-text field** with no `key=`/`:` delimiter is matched by none of the structured passes and would ship to the export unredacted.

This adds a last-resort pass: `sk-ant-[A-Za-z0-9_-]{1,512}` scrubbed wherever it appears, guarded by `if result.contains("sk-ant-")` so there's zero cost on the common path. The prefix is unambiguous, so no over-redaction risk.

## Reachability: latent, not a live leak

Traced on `main`: the only free-text diagnostic vector is the login-state milestone `"error: \(message)"` (`AuthManager.swift:469`). All 8 producers of that `message` pass **static string literals** ("Connection error. Please try again.", etc.) — no token or response body is interpolated today. So nothing leaks in v1.50 as shipped. This is defense-in-depth against a future error path that interpolates a session token/API body into that field and would otherwise ship it unredacted with a green suite.

## Verification

Standalone `swiftc` harness against the ported `SecretRedactor` (self-contained; xcodebuild skipped — Gatekeeper-prone locally, and there is no macOS test CI). 7/7 green:

- free-text `sk-ant-` scrubbed; surrounding non-secret words survive
- structured `sessionKey=` still scrubbed (regression guard)
- NoSecretsExportGate sentinel (error message embedding token + email): both scrubbed
- benign `ant`/`antenna` text untouched (no over-redaction)
- nested `{"token":["sk-ant-…"]}` still scrubbed

The commit also adds a `NoSecretsExportGateTests` case that drives the sentinel through the real producer → redactor → archive pipeline. **Run the full XCTest suite on a signed host before merge** — no macOS CI runs it here.

## Note

Source branch `rc/dry-run-2026-06-16` held the never-shipped email-signin steering funnel (issues #7/#17/#25, all now closed — v1.50 fixed them via the email-code path). The funnel is superseded; this redaction backstop was its one piece worth keeping. Branch retired after this port.

Co-Authored-By: Princess Fiona of Far Far Away (Opus 4.8 (1M context)) <noreply@anthropic.com>
