### PR TITLE
fix(diagnostics): drop dead file handle after a write failure

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Services/DiagnosticsLogger.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/DiagnosticsLogger.swift
@@ -218,6 +218,10 @@ final class DiagnosticsLogger: @unchecked Sendable {
             try handle.synchronize()
         } catch {
             logger.notice("[write-failed] \(error.localizedDescription, privacy: .public)")
+            // Drop the dead handle so later milestones degrade to the os_log [file-unavailable]
+            // path instead of re-fsyncing a broken handle every line (e.g. transient disk-full).
+            try? handle.close()
+            fileHandle = nil
         }
     }
 


### PR DESCRIPTION
## What

On a diagnostics write failure, drop the dead file handle so later log lines fall back to os_log instead of retrying a broken handle. 4-line change to `DiagnosticsLogger.writeLineLocked`.

## Why

Shipped v1.50, on a write failure, logs the error but keeps the `FileHandle` and calls `synchronize()` on it again for every subsequent milestone (e.g. transient disk-full), re-failing every line. `writeLineLocked` already has a nil-handle guard that degrades to the os_log `[file-unavailable]` path — this fix nils the handle after a failure so that guard actually engages.

## Provenance

Salvaged from the retired `rc/dry-run-2026-06-16` branch (funnel review commit `24619c2`, finding R1) before that branch was deleted. The steering funnel it belonged to is superseded (issues #7/#17/#25 closed, fixed another way in v1.50), but this one hunk is real hardening to shipped code and was absent from main. Split out as its own PR; the redaction backstop from the same branch is in #33.

## Verification

Logic verified by reading: nil handle -> existing `[file-unavailable]` guard (`writeLineLocked:211`). Not runtime-triggered (needs a real write failure e.g. disk-full). No macOS test CI in this repo — run the XCTest suite on a signed host before merge.

Co-Authored-By: Princess Fiona of Far Far Away (Opus 4.8 (1M context)) <noreply@anthropic.com>
