### PR TITLE
fix(auth): let manual sign-in add a second org of the same account (#32)

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AccountStore.swift
@@ -131,6 +131,23 @@ class AccountStore: ObservableObject {
         persist()
     }
 
+    // MARK: - Display
+
+    /// Name to show for an account, disambiguated by org name ONLY when another stored account
+    /// shares the same email (two orgs of one Claude account — issue #32). A nickname always wins.
+    /// Single-org accounts, unique-email accounts, and accounts with no stored org name render
+    /// exactly as `Account.displayName` (nickname ?? email), so existing users see no change.
+    func disambiguatedName(for account: Account) -> String {
+        if let nickname = account.nickname, !nickname.isEmpty {
+            return nickname
+        }
+        let sharesEmail = accounts.contains { $0.id != account.id && $0.email == account.email }
+        if sharesEmail, let orgName = account.organizationName, !orgName.isEmpty {
+            return "\(account.email) (\(orgName))"
+        }
+        return account.displayName
+    }
+
     // MARK: - Persistence
 
     private func persist() {

--- a/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/AuthManager.swift
@@ -33,6 +33,9 @@ enum ManualSignInResult: Equatable {
     case success(String)
     /// Multiple orgs with no existing match — the user must pick one (pattern #6).
     case needsOrgChoice([Organization])
+    /// Every org on the account is already stored (any N >= 2); the matched session was refreshed
+    /// rather than a new account added (issue #32, KTD-3).
+    case alreadySignedInAllOrgs
     /// The paste did not contain a usable `sessionKey`.
     case invalidInput
     /// 401/403 from claude.ai. `suggestFullHeader` is true when only a bare key was pasted,
@@ -722,13 +725,18 @@ class AuthManager: NSObject, ObservableObject {
     // MARK: - Org Discovery
 
     /// Pure org-selection rule (pattern #6: never blindly take orgs[0]) shared by the WebView and
-    /// manual-paste sign-in paths. Single org -> take it; else if an existing account's org is in
-    /// the list -> auto-select that match; else the caller must show a picker. Unit-tested in
-    /// isolation; each call site supplies its own side-effect shell (NSAlert vs ManualSignInResult).
+    /// manual-paste sign-in paths. Single org -> take it; a multi-org account with at least one
+    /// un-added org -> the caller shows a picker (so a second org of the same account is reachable,
+    /// issue #32); a multi-org account where every org is already stored -> the caller refreshes
+    /// the matched session and reports it. There is deliberately NO silent auto-match: the same
+    /// paste is used both to refresh an existing org and to add a different org of the same account,
+    /// so when an addable org exists the user must choose. Unit-tested in isolation; each call site
+    /// supplies its own side-effect shell (NSAlert vs ManualSignInResult).
     enum OrgSelection {
         case single(Organization)
-        case autoMatched(Organization, accountId: UUID)
         case needsChoice([Organization])
+        /// Every org on the account is already stored — refresh, do not add (KTD-3).
+        case allAlreadyAdded([Organization])
     }
 
     // `nonisolated`: a pure rule over value types, so it needs no main-actor isolation and can be
@@ -737,11 +745,24 @@ class AuthManager: NSObject, ObservableObject {
         if orgs.count == 1 {
             return .single(orgs[0])
         }
-        if let existing = accounts.first(where: { acct in orgs.contains(where: { $0.uuid == acct.organizationId }) }),
-           let match = orgs.first(where: { $0.uuid == existing.organizationId }) {
-            return .autoMatched(match, accountId: existing.id)
+        let unadded = orgs.filter { org in !accounts.contains(where: { $0.organizationId == org.uuid }) }
+        if unadded.isEmpty {
+            return .allAlreadyAdded(orgs)
         }
         return .needsChoice(orgs)
+    }
+
+    /// The stored account to refresh when every org is already added (`.allAlreadyAdded`): the
+    /// active account when its org is in the list, else the first stored match. Active-preference
+    /// is mandatory, not cosmetic — `AccountStore.updateSessionKey` re-primes the shared cookie jar
+    /// only for the active account, so refreshing a non-active sibling while the active account's
+    /// org is present would leave the live session unrefreshed (KTD-3).
+    func matchedAccount(in orgs: [Organization]) -> Account? {
+        if let active = accountStore.activeAccount,
+           orgs.contains(where: { $0.uuid == active.organizationId }) {
+            return active
+        }
+        return accountStore.accounts.first { acct in orgs.contains { $0.uuid == acct.organizationId } }
     }
 
     // internal for @testable access in AuthManagerTests
@@ -808,11 +829,24 @@ class AuthManager: NSObject, ObservableObject {
             switch Self.selectOrg(orgs: orgs, accounts: accountStore.accounts) {
             case .single(let org):
                 chosenOrg = org
-            case .autoMatched(let org, let accountId):
-                chosenOrg = org
-                // Log the non-PII account id, not displayName (= email when no nickname) or the
-                // org name — both can carry PII, and os_log lines can be read off-device.
-                logger.info("Re-auth auto-selected org for account \(accountId.uuidString)")
+            case .allAlreadyAdded:
+                // Every org on this account is already stored. This is a foreground sign-in the
+                // user just completed, so refresh the matched account and switch to it (KTD-3
+                // WebView branch — unlike the manual path, switching is expected here). Log the
+                // non-PII account id only; displayName/org name can carry PII in off-device logs.
+                guard let matched = matchedAccount(in: orgs) else {
+                    handleOrgDiscoveryFailure("Account limit reached.")
+                    return
+                }
+                accountStore.updateSessionKey(matched.id, sessionKey, cookieHeader: pendingCookieHeader)
+                accountStore.switchTo(matched.id)
+                logger.info("Re-auth: all orgs already added, refreshed account \(matched.id.uuidString)")
+                pendingSessionKey = nil
+                pendingCookieHeader = nil
+                loginState = .idle
+                stopLoginWindow()
+                onAuthSuccess?()
+                return
             case .needsChoice(let choices):
                 let picked = await showOrgPicker(orgs: choices)
                 // If teardown (timeout / window close) resumed the picker with nil, orgDiscoveryTask
@@ -835,6 +869,7 @@ class AuthManager: NSObject, ObservableObject {
                 email: email,
                 sessionKey: sessionKey,
                 organizationId: chosenOrg.uuid,
+                organizationName: chosenOrg.sanitizedName,
                 allCookieHeader: pendingCookieHeader
             )
 
@@ -898,6 +933,10 @@ class AuthManager: NSObject, ObservableObject {
                 let duplicateCount = orgs.prefix(index).filter { $0.displayName == org.displayName && org.displayName != "Organization" }.count
                 if duplicateCount > 0 {
                     title = "\(title) (\(duplicateCount + 1))"
+                }
+                // Mark orgs already stored so the user can tell an "add" choice from a "reactivate".
+                if accountStore.accounts.contains(where: { $0.organizationId == org.uuid }) {
+                    title = "\(title) (already added)"
                 }
                 popup.addItem(withTitle: title)
             }
@@ -1060,14 +1099,37 @@ class AuthManager: NSObject, ObservableObject {
             switch Self.selectOrg(orgs: orgs, accounts: accountStore.accounts) {
             case .single(let org):
                 selectedOrg = org
-            case .autoMatched(let org, _):
-                selectedOrg = org
             case .needsChoice(let choices):
                 // Restore the active account's jar while the picker is shown; completeManualSignIn
                 // re-primes the jar to the chosen account via switchTo.
                 restoreActiveJar()
                 pendingManualSignIn = (sessionKey, cookieHeader, email)
                 return .needsOrgChoice(choices)
+            case .allAlreadyAdded:
+                // Every org on this account is already stored. Refresh the matched account's
+                // session and report it (KTD-3). Early-return here so this bypasses the trailing
+                // `if case .success = result {} else { restoreActiveJar() }` guard below — Branch A
+                // must NOT restore, or it would undo the refresh it just primed into the jar.
+                guard let matched = matchedAccount(in: orgs) else {
+                    restoreActiveJar()
+                    return .accountLimitReached
+                }
+                accountStore.updateSessionKey(matched.id, sessionKey, cookieHeader: cookieHeader)
+                if matched.id == accountStore.activeAccountId {
+                    // Branch A — matched IS active: updateSessionKey already re-primed the jar to
+                    // the fresh cookies. Do not restore, do not switch. Fire onAuthSuccess so
+                    // polling restarts (recovers an active session that had gone authFailed).
+                    logger.info("Manual sign-in: all orgs already added, refreshed active account")
+                    onAuthSuccess?()
+                } else {
+                    // Branch B — matched is NOT active: persist fresh creds on the sibling, then
+                    // restore the real active account's jar so it keeps serving its own cookies.
+                    // Do not switch (a paste must not silently switch the active account) and do
+                    // not fire onAuthSuccess (the active account was left untouched).
+                    restoreActiveJar()
+                    logger.info("Manual sign-in: all orgs already added, refreshed a background account")
+                }
+                return .alreadySignedInAllOrgs
             }
 
             let result = addOrReactivateManualAccount(org: selectedOrg, sessionKey: sessionKey, cookieHeader: cookieHeader, email: email)
@@ -1083,18 +1145,19 @@ class AuthManager: NSObject, ObservableObject {
     }
 
     private func addOrReactivateManualAccount(org: Organization, sessionKey: String, cookieHeader: String?, email: String) -> ManualSignInResult {
-        let account = Account(email: email, sessionKey: sessionKey, organizationId: org.uuid, allCookieHeader: cookieHeader)
+        let account = Account(email: email, sessionKey: sessionKey, organizationId: org.uuid, organizationName: org.sanitizedName, allCookieHeader: cookieHeader)
         if accountStore.addAccount(account) {
             accountStore.switchTo(account.id)
             logger.info("Manual sign-in added a new account")
             onAuthSuccess?()
-            return .success(account.displayName)
+            // Disambiguated so adding org B of a same-email account confirms which org (issue #32).
+            return .success(accountStore.disambiguatedName(for: account))
         } else if let existing = accountStore.accounts.first(where: { $0.organizationId == org.uuid }) {
             accountStore.updateSessionKey(existing.id, sessionKey, cookieHeader: cookieHeader)
             accountStore.switchTo(existing.id)
             logger.info("Manual sign-in reactivated an existing account")
             onAuthSuccess?()
-            return .success(existing.displayName)
+            return .success(accountStore.disambiguatedName(for: existing))
         }
         return .accountLimitReached
     }
@@ -1462,10 +1525,20 @@ struct Organization: Codable, Equatable {
     let billingType: String?
     let emailAddress: String?
 
+    /// The org's real name, sanitized (newline/RTL-mark strip, 100-char cap), or nil when the org
+    /// has no usable name. This is what gets stored on `Account.organizationName`, so a persisted
+    /// org name matches how the name renders everywhere else and never carries the `displayName`
+    /// "Organization"/billing-type fallback.
+    var sanitizedName: String? {
+        guard let name, !name.isEmpty else { return nil }
+        let sanitized = name.filter { !$0.isNewline && $0 != "\u{200F}" && $0 != "\u{200E}" }
+        let capped = String(sanitized.prefix(100))
+        return capped.isEmpty ? nil : capped
+    }
+
     var displayName: String {
-        if let name, !name.isEmpty {
-            let sanitized = name.filter { !$0.isNewline && $0 != "\u{200F}" && $0 != "\u{200E}" }
-            return String(sanitized.prefix(100))
+        if let sanitizedName {
+            return sanitizedName
         }
         if let billingType, !billingType.isEmpty {
             return billingType.capitalized

--- a/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/StorageService.swift
@@ -10,6 +10,10 @@ struct Account: Codable, Identifiable, Equatable {
     var email: String
     var sessionKey: String
     var organizationId: String
+    /// The org's display name, captured at add time (sanitized like `Organization.displayName`).
+    /// Used only to disambiguate two orgs of the SAME account in the UI. Optional and additive:
+    /// accounts persisted before issue #32 decode this as nil and render by email as before.
+    var organizationName: String?
     var nickname: String?
     let addedDate: Date
     var notificationThreshold: Double
@@ -25,11 +29,12 @@ struct Account: Codable, Identifiable, Equatable {
         nickname ?? email
     }
 
-    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, allCookieHeader: String? = nil) {
+    init(id: UUID = UUID(), email: String, sessionKey: String, organizationId: String, organizationName: String? = nil, nickname: String? = nil, addedDate: Date = Date(), notificationThreshold: Double = 20.0, didNotifyBelowThreshold: Bool = false, allCookieHeader: String? = nil) {
         self.id = id
         self.email = email
         self.sessionKey = sessionKey
         self.organizationId = organizationId
+        self.organizationName = organizationName
         self.nickname = nickname
         self.addedDate = addedDate
         self.notificationThreshold = notificationThreshold

--- a/ClaudeBattery/ClaudeBattery/Views/SettingsView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/SettingsView.swift
@@ -151,7 +151,7 @@ struct SettingsView: View {
                 .frame(width: 8, height: 8)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text(account.displayName)
+                Text(accountStore.disambiguatedName(for: account))
                     .font(.body)
                 if account.nickname != nil {
                     Text(account.email)
@@ -250,7 +250,8 @@ private struct ManualSignInSection: View {
             if !orgChoices.isEmpty {
                 Picker("Organization", selection: $selectedOrgIndex) {
                     ForEach(Array(orgChoices.enumerated()), id: \.offset) { index, org in
-                        Text(org.displayName).tag(index)
+                        let alreadyAdded = authManager.accountStore.accounts.contains { $0.organizationId == org.uuid }
+                        Text(alreadyAdded ? "\(org.displayName) (already added)" : org.displayName).tag(index)
                     }
                 }
                 Button("Use this organization") { chooseOrg() }
@@ -298,6 +299,11 @@ private struct ManualSignInSection: View {
             selectedOrgIndex = 0
             statusIsError = false
             statusText = "Multiple organizations found. Choose one to finish."
+        case .alreadySignedInAllOrgs:
+            statusIsError = false
+            statusText = "You're already signed in to all organizations on this account. Refreshed the session."
+            pasted = ""
+            orgChoices = []
         case .invalidInput:
             statusIsError = true
             statusText = "That doesn't look like a cookie header. Paste the full Cookie value, or your sessionKey."

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -705,7 +705,7 @@ private struct AccountListSection: View {
                     .fill(isActive ? Color.green : Color(white: 0.4))
                     .frame(width: 7, height: 7)
 
-                Text(account.displayName)
+                Text(accountStore.disambiguatedName(for: account))
                     .font(.system(size: 11))
                     .foregroundColor(.white)
                     .lineLimit(1)

--- a/ClaudeBattery/ClaudeBatteryTests/AccountStoreTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/AccountStoreTests.swift
@@ -195,4 +195,59 @@ final class AccountStoreTests: XCTestCase {
         XCTAssertEqual(store2.accounts.first, account)
         XCTAssertEqual(store2.activeAccountId, account.id)
     }
+
+    // MARK: - Display: disambiguatedName (issue #32 — two orgs of the same account)
+
+    @MainActor
+    func testDisambiguatedName_uniqueEmailShowsEmail() {
+        let store = AccountStore(storage: makeStorage())
+        let a = Account(email: "solo@x.com", sessionKey: "sk", organizationId: "org-1", organizationName: "Acme")
+        _ = store.addAccount(a)
+        XCTAssertEqual(store.disambiguatedName(for: a), "solo@x.com",
+                       "a unique email renders plainly even when an org name exists")
+    }
+
+    @MainActor
+    func testDisambiguatedName_sameEmailAppendsOrgName() {
+        let store = AccountStore(storage: makeStorage())
+        let a = Account(email: "me@x.com", sessionKey: "sk", organizationId: "org-a", organizationName: "Acme")
+        let b = Account(email: "me@x.com", sessionKey: "sk", organizationId: "org-b", organizationName: "Beta")
+        _ = store.addAccount(a)
+        _ = store.addAccount(b)
+        XCTAssertEqual(store.disambiguatedName(for: a), "me@x.com (Acme)")
+        XCTAssertEqual(store.disambiguatedName(for: b), "me@x.com (Beta)")
+    }
+
+    @MainActor
+    func testDisambiguatedName_nicknameAlwaysWins() {
+        let store = AccountStore(storage: makeStorage())
+        let a = Account(email: "me@x.com", sessionKey: "sk", organizationId: "org-a", organizationName: "Acme", nickname: "Work")
+        let b = Account(email: "me@x.com", sessionKey: "sk", organizationId: "org-b", organizationName: "Beta")
+        _ = store.addAccount(a)
+        _ = store.addAccount(b)
+        XCTAssertEqual(store.disambiguatedName(for: a), "Work", "a nickname overrides email/org disambiguation")
+    }
+
+    @MainActor
+    func testDisambiguatedName_sameEmailButNoOrgNameFallsBackToEmail() {
+        let store = AccountStore(storage: makeStorage())
+        // Accounts migrated from before issue #32 have nil organizationName; they cannot
+        // disambiguate and must fall back to the email, unchanged from before.
+        let a = Account(email: "me@x.com", sessionKey: "sk", organizationId: "org-a")
+        let b = Account(email: "me@x.com", sessionKey: "sk", organizationId: "org-b")
+        _ = store.addAccount(a)
+        _ = store.addAccount(b)
+        XCTAssertEqual(store.disambiguatedName(for: a), "me@x.com")
+    }
+
+    // MARK: - Codable migration: legacy Account JSON without organizationName (R7, #32)
+
+    func testAccountDecodesLegacyJSONWithoutOrganizationName() throws {
+        let legacy = """
+        {"id":"\(UUID().uuidString)","email":"old@x.com","sessionKey":"sk","organizationId":"org-1","addedDate":0,"notificationThreshold":20,"didNotifyBelowThreshold":false}
+        """.data(using: .utf8)!
+        let account = try JSONDecoder().decode(Account.self, from: legacy)
+        XCTAssertNil(account.organizationName, "a missing organizationName key decodes as nil")
+        XCTAssertEqual(account.displayName, "old@x.com", "legacy account still renders by email")
+    }
 }

--- a/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/AuthManagerTests.swift
@@ -850,15 +850,28 @@ final class AuthManagerTests: XCTestCase {
         XCTAssertEqual(org.uuid, "org-a")
     }
 
-    func testSelectOrg_multiOrg_autoMatchesExistingAccountOrg() {
+    func testSelectOrg_multiOrg_oneAlreadyStored_requiresChoice() {
+        // Issue #32: the silent auto-match is gone. When one org of a multi-org account is already
+        // stored, selectOrg must return .needsChoice (not reuse the stored org) so the picker can
+        // offer the second, un-added org.
         let a = Organization(uuid: "org-a", name: nil, billingType: nil, emailAddress: nil)
         let b = Organization(uuid: "org-b", name: nil, billingType: nil, emailAddress: nil)
         let acct = Account(email: "x@test.com", sessionKey: "sk", organizationId: "org-b", allCookieHeader: nil)
-        guard case .autoMatched(let org, let accountId) = AuthManager.selectOrg(orgs: [a, b], accounts: [acct]) else {
-            return XCTFail("an existing account's org present in the list should auto-match")
+        guard case .needsChoice(let choices) = AuthManager.selectOrg(orgs: [a, b], accounts: [acct]) else {
+            return XCTFail("one-of-two orgs stored must still require a choice, not silently auto-match")
         }
-        XCTAssertEqual(org.uuid, "org-b")
-        XCTAssertEqual(accountId, acct.id)
+        XCTAssertEqual(choices.map(\.uuid), ["org-a", "org-b"])
+    }
+
+    func testSelectOrg_multiOrg_allAlreadyStored_reportsAllAdded() {
+        let a = Organization(uuid: "org-a", name: nil, billingType: nil, emailAddress: nil)
+        let b = Organization(uuid: "org-b", name: nil, billingType: nil, emailAddress: nil)
+        let acctA = Account(email: "x@test.com", sessionKey: "sk", organizationId: "org-a", allCookieHeader: nil)
+        let acctB = Account(email: "x@test.com", sessionKey: "sk", organizationId: "org-b", allCookieHeader: nil)
+        guard case .allAlreadyAdded(let orgs) = AuthManager.selectOrg(orgs: [a, b], accounts: [acctA, acctB]) else {
+            return XCTFail("every org already stored must report .allAlreadyAdded, not a picker")
+        }
+        XCTAssertEqual(orgs.map(\.uuid), ["org-a", "org-b"])
     }
 
     func testSelectOrg_multiOrg_noExistingMatch_requiresChoice_neverOrgsZero() {
@@ -869,6 +882,156 @@ final class AuthManagerTests: XCTestCase {
             return XCTFail("multi-org with no existing match must require a choice, never blindly orgs[0]")
         }
         XCTAssertEqual(choices.map(\.uuid), ["org-a", "org-b"])
+    }
+
+    // MARK: - Issue #32: reach a second org of the same account; jar discipline when all stored
+
+    @MainActor
+    func testManualSignIn_addsSecondOrgOfSameAccount() async {
+        let auth = makeAuthManager()
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-A",
+            organizationId: "org-a", organizationName: "Acme", allCookieHeader: "sessionKey=sk-A"))
+
+        mockSession.responseData = #"[{"uuid":"org-a","name":"Acme","email_address":"me@x.com"},{"uuid":"org-b","name":"Beta","email_address":"me@x.com"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+
+        let result = await auth.manualSignIn("sessionKey=sk-fresh; __cf_bm=cf")
+        guard case .needsOrgChoice(let orgs) = result else {
+            return XCTFail("one org stored, one addable must show the picker, got \(result)")
+        }
+        XCTAssertEqual(orgs.map(\.uuid), ["org-a", "org-b"])
+
+        let completed = auth.completeManualSignIn(org: orgs[1])
+        guard case .success = completed else { return XCTFail("adding org-b should succeed, got \(completed)") }
+        XCTAssertEqual(auth.accountStore.accounts.count, 2, "both orgs of the account persist as separate accounts")
+        XCTAssertTrue(auth.accountStore.accounts.contains { $0.organizationId == "org-a" })
+        XCTAssertTrue(auth.accountStore.accounts.contains { $0.organizationId == "org-b" })
+    }
+
+    @MainActor
+    func testManualSignIn_pickingStoredOrgReactivatesNoDuplicate() async {
+        let auth = makeAuthManager()
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-old",
+            organizationId: "org-a", allCookieHeader: "sessionKey=sk-old"))
+
+        mockSession.responseData = #"[{"uuid":"org-a"},{"uuid":"org-b"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+
+        let result = await auth.manualSignIn("sessionKey=sk-new; __cf_bm=cf")
+        guard case .needsOrgChoice(let orgs) = result else { return XCTFail("expected picker, got \(result)") }
+        // Re-pick org-a (already stored) to refresh it.
+        let completed = auth.completeManualSignIn(org: orgs[0])
+        guard case .success = completed else { return XCTFail("reactivating org-a should succeed") }
+        XCTAssertEqual(auth.accountStore.accounts.count, 1, "reactivate, not duplicate")
+        XCTAssertEqual(auth.accountStore.accounts.first?.sessionKey, "sk-new", "session refreshed")
+    }
+
+    @MainActor
+    func testManualSignIn_allOrgsStored_activeMatched_refreshesJarBranchA() async {
+        let auth = makeAuthManager()
+        let url = URL(string: "https://claude.ai")!
+        func jarSessionKey() -> String? {
+            ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: url)?.first { $0.name == "sessionKey" }?.value
+        }
+        // Both orgs of the account are stored; the org-a account is active with STALE cookies.
+        let a = Account(email: "me@x.com", sessionKey: "sk-stale", organizationId: "org-a",
+                        allCookieHeader: "sessionKey=sk-stale; __cf_bm=cf-stale")
+        _ = auth.accountStore.addAccount(a)
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-b",
+                        organizationId: "org-b", allCookieHeader: "sessionKey=sk-b"))
+        auth.accountStore.switchTo(a.id)
+        XCTAssertEqual(jarSessionKey(), "sk-stale", "precondition: jar holds the active account's stale cookies")
+
+        mockSession.responseData = #"[{"uuid":"org-a"},{"uuid":"org-b"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+
+        let result = await auth.manualSignIn("sessionKey=sk-fresh; __cf_bm=cf-fresh")
+
+        XCTAssertEqual(result, .alreadySignedInAllOrgs)
+        XCTAssertEqual(auth.accountStore.activeAccountId, a.id, "active account unchanged, no switch")
+        XCTAssertEqual(auth.accountStore.accounts.first { $0.id == a.id }?.sessionKey, "sk-fresh",
+                       "the active account's stored session is refreshed to the pasted value")
+        XCTAssertEqual(jarSessionKey(), "sk-fresh",
+                       "Branch A: the shared jar serves the FRESH cookies, not the stale snapshot (no restore)")
+    }
+
+    @MainActor
+    func testManualSignIn_allOrgsStored_activeNotInList_restoresJarBranchB() async {
+        let auth = makeAuthManager()
+        let url = URL(string: "https://claude.ai")!
+        func jarSessionKey() -> String? {
+            ClaudeAPI.session.configuration.httpCookieStorage?.cookies(for: url)?.first { $0.name == "sessionKey" }?.value
+        }
+        // Active account C is unrelated to the pasted account (orgs a, b), both already stored.
+        let c = Account(email: "c@other.com", sessionKey: "sk-C", organizationId: "org-c",
+                        allCookieHeader: "sessionKey=sk-C; __cf_bm=cf-C")
+        _ = auth.accountStore.addAccount(c)
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-a", organizationId: "org-a", allCookieHeader: "sessionKey=sk-a"))
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-b", organizationId: "org-b", allCookieHeader: "sessionKey=sk-b"))
+        auth.accountStore.switchTo(c.id)
+        XCTAssertEqual(jarSessionKey(), "sk-C", "precondition: jar holds active account C")
+
+        mockSession.responseData = #"[{"uuid":"org-a"},{"uuid":"org-b"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+
+        let result = await auth.manualSignIn("sessionKey=sk-fresh; __cf_bm=cf-fresh")
+
+        XCTAssertEqual(result, .alreadySignedInAllOrgs)
+        XCTAssertEqual(auth.accountStore.activeAccountId, c.id, "active account C is unchanged, no silent switch")
+        XCTAssertEqual(jarSessionKey(), "sk-C",
+                       "Branch B: the real active account C keeps serving its own cookies (jar restored)")
+    }
+
+    @MainActor
+    func testManualSignIn_allOrgsStored_threeOrgs_isCountAgnostic() async {
+        let auth = makeAuthManager()
+        for uuid in ["org-a", "org-b", "org-c"] {
+            _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-\(uuid)",
+                organizationId: uuid, allCookieHeader: "sessionKey=sk-\(uuid)"))
+        }
+        mockSession.responseData = #"[{"uuid":"org-a"},{"uuid":"org-b"},{"uuid":"org-c"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+        let result = await auth.manualSignIn("sessionKey=sk-fresh; __cf_bm=cf")
+        XCTAssertEqual(result, .alreadySignedInAllOrgs, "N>=2 all-stored reports the same result regardless of count")
+    }
+
+    @MainActor
+    func testFetchOrganizationId_partialStored_showsPickerNotAutoMatch() async {
+        let auth = makeAuthManager()
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-a",
+            organizationId: "org-a", allCookieHeader: "sessionKey=sk-a"))
+        mockSession.responseData = #"[{"uuid":"org-a"},{"uuid":"org-b"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+        auth.pendingSessionKey = "sk-fresh"
+
+        await auth.fetchOrganizationId()
+
+        // No login window in tests, so .needsChoice -> picker returns nil -> graceful failure. The
+        // point: it routed to .needsChoice, NOT the removed .autoMatched (which would have silently
+        // reactivated org-a and overwritten its sessionKey with sk-fresh — the #32 bug).
+        XCTAssertEqual(auth.accountStore.accounts.count, 1, "no account added or removed")
+        XCTAssertEqual(auth.accountStore.accounts.first?.sessionKey, "sk-a",
+                       "org-a must NOT be silently reactivated")
+    }
+
+    @MainActor
+    func testFetchOrganizationId_allStored_refreshesMatchedAndSwitches() async {
+        let auth = makeAuthManager()
+        let a = Account(email: "me@x.com", sessionKey: "sk-a-old", organizationId: "org-a", allCookieHeader: "sessionKey=sk-a-old")
+        _ = auth.accountStore.addAccount(a)
+        _ = auth.accountStore.addAccount(Account(email: "me@x.com", sessionKey: "sk-b", organizationId: "org-b", allCookieHeader: "sessionKey=sk-b"))
+        auth.accountStore.switchTo(a.id)
+        mockSession.responseData = #"[{"uuid":"org-a"},{"uuid":"org-b"}]"#.data(using: .utf8)!
+        mockSession.responseStatusCode = 200
+        auth.pendingSessionKey = "sk-a-fresh"
+
+        await auth.fetchOrganizationId()
+
+        XCTAssertEqual(auth.accountStore.accounts.count, 2, "all-stored: no new account")
+        XCTAssertEqual(auth.accountStore.activeAccountId, a.id)
+        XCTAssertEqual(auth.accountStore.accounts.first { $0.id == a.id }?.sessionKey, "sk-a-fresh",
+                       "WebView all-stored refreshes the matched account's session")
+        XCTAssertEqual(auth.loginState, .idle, "window closes via the success path")
     }
 
     // MARK: - fetchOrganizationId: Happy Path — single org creates account

--- a/ClaudeBattery/ClaudeBatteryTests/OrganizationTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/OrganizationTests.swift
@@ -63,6 +63,29 @@ final class OrganizationTests: XCTestCase {
         XCTAssertThrowsError(try JSONDecoder().decode([Organization].self, from: json))
     }
 
+    // MARK: - sanitizedName (stored on Account for disambiguation, issue #32)
+
+    func testSanitizedName_nilWhenNoName() {
+        let org = Organization(uuid: "o", name: nil, billingType: "pro", emailAddress: nil)
+        XCTAssertNil(org.sanitizedName, "no real name -> nil (billingType is a displayName fallback, not a name)")
+    }
+
+    func testSanitizedName_stripsNewlinesAndRTLMarks() {
+        let org = Organization(uuid: "o", name: "Ac\nme\u{200F}", billingType: nil, emailAddress: nil)
+        XCTAssertEqual(org.sanitizedName, "Acme")
+    }
+
+    func testSanitizedName_capsAt100Chars() {
+        let org = Organization(uuid: "o", name: String(repeating: "x", count: 150), billingType: nil, emailAddress: nil)
+        XCTAssertEqual(org.sanitizedName?.count, 100)
+    }
+
+    func testDisplayName_stillFallsBackToBillingTypeThenOrganization() {
+        XCTAssertEqual(Organization(uuid: "o", name: nil, billingType: "pro", emailAddress: nil).displayName, "Pro")
+        XCTAssertEqual(Organization(uuid: "o", name: nil, billingType: nil, emailAddress: nil).displayName, "Organization")
+        XCTAssertEqual(Organization(uuid: "o", name: "Acme", billingType: nil, emailAddress: nil).displayName, "Acme")
+    }
+
     // MARK: - Helpers
 
     private func fixtureData(_ name: String) throws -> Data {


### PR DESCRIPTION
## What

Manual cookie-paste sign-in could not add the second organization of an account whose first org was already stored. The shared org-selection rule silently reused the stored org and never showed the picker, so the second org was unreachable and the paste read as a no-op re-login.

## Fix

- `selectOrg` drops the silent `.autoMatched` path and adds `.allAlreadyAdded`: a multi-org account always routes through the picker while an org is still addable, and reports a clean "already signed in to all organizations" refresh when every org is stored. The WebView and manual-paste paths share the rule, so both are fixed at once.
- `.allAlreadyAdded` keeps strict cookie-jar discipline (refresh the active-matched account in place, or a background sibling with a jar restore and no switch) so the shared jar never serves the wrong account.
- Two orgs of one account are told apart in the account list by a stored, sanitized org name, shown only when another account shares the email. Accounts migrated from older builds (no stored name) render unchanged.

## Testing

Full XCTest suite green on macOS: 400 tests, 0 failures. Coverage includes both `.allAlreadyAdded` jar branches, org-name disambiguation, and legacy (no-name) decode.

Refs #32

Co-Authored-By: Princess Fiona of Far Far Away (Claude Opus 4.8) <noreply@anthropic.com>
