### PR TITLE
fix(site): use the app's coral accent (#D95F47) for readable buttons on dark

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -33,8 +33,8 @@
       --bg-alt: #F5F5F4;
       --text: #1C1917;
       --text-muted: #57534E;
-      --accent: #EA580C;
-      --accent-hover: #C2410C;
+      --accent: #D95F47;
+      --accent-hover: #C24E38;
       --border: #E7E5E4;
       --card-bg: #FFFFFF;
       --code-bg: #292524;
@@ -49,8 +49,8 @@
         --bg-alt: #292524;
         --text: #FAFAF9;
         --text-muted: #A8A29E;
-        --accent: #FB923C;
-        --accent-hover: #F97316;
+        --accent: #D95F47;
+        --accent-hover: #C24E38;
         --border: #44403C;
         --card-bg: #292524;
         --shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Switches the site accent from the pale dark-mode orange (#FB923C, ~2:1 white-text contrast) to the app icon's coral **#D95F47** in both light and dark mode. White button text reads at ~3.7:1 (matching the previous light-mode orange), the button stands out on the dark background, and the site now matches the menu-bar icon.

Verified in-browser: dark mode (the reported context) shows the coral button with readable white text; light mode confirmed the coral works on white too.

Co-Authored-By: Landon "Happy" Gilmore (Claude Opus 4.8 (1M context)) <noreply@anthropic.com>