### PR TITLE
fix(usage): show the same Session number in the menu bar and the popover

### DIFF
--- a/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
+++ b/ClaudeBattery/ClaudeBattery/Services/UsageService.swift
@@ -593,26 +593,26 @@ struct UsageData: Equatable {
 
     /// Weekly-remaining floor (percent) below which the weekly limit is treated as the
     /// near-term binding constraint. Matches the popover's red color line (batteryColor red
-    /// < 20) so a weekly in the red gates the Session gauge. See `sessionGaugeRemaining`.
+    /// < 20) so a weekly in the red gates the Session value. See `sessionDisplayRemaining`.
     static let weeklyGateFloor: Double = 20
 
     /// True when the weekly limit is BOTH lower than the session AND in its low/red zone, so
     /// the weekly - not the 5h session - is the wall the user hits next. Only then does the
-    /// popover Session gauge defer to the weekly remainder, fixing the case where a
+    /// displayed Session value defer to the weekly remainder, fixing the case where a
     /// nearly-exhausted weekly still showed a high, unreachable session number. Above the
     /// floor (a healthy week), or when the session is already the tighter limit, this is false
-    /// and the gauge shows the true session value - so normal weeks are never down-rated.
+    /// and the true session value is shown - so normal weeks are never down-rated.
     var isSessionWeeklyLimited: Bool {
         weeklyRemaining < sessionRemaining && weeklyRemaining < UsageData.weeklyGateFloor
     }
 
-    /// Value the popover Session gauge should DISPLAY: the true 5h-session remaining, but
-    /// capped to the weekly remainder when the weekly limit binds (`isSessionWeeklyLimited`)
-    /// so the dial never shows session headroom a near-exhausted weekly cannot support.
-    /// Display-only and popover-only: raw `sessionRemaining` is left untouched for the
-    /// menu-bar icons (which already show session and weekly side by side) and for the #31
-    /// session run-out forecast, both of which must keep the true 5h value.
-    var sessionGaugeRemaining: Double {
+    /// The Session value every surface DISPLAYS: the true 5h-session remaining, but capped to
+    /// the weekly remainder when the weekly limit binds (`isSessionWeeklyLimited`), so nothing
+    /// shows session headroom a near-exhausted weekly cannot support. Used by both the popover
+    /// dial and the menu-bar icons - they must never disagree about a number both label
+    /// "Session". Display-only: raw `sessionRemaining` stays untouched for the #31 session
+    /// run-out forecast and pace, which grade the real 5h window.
+    var sessionDisplayRemaining: Double {
         isSessionWeeklyLimited ? weeklyRemaining : sessionRemaining
     }
 

--- a/ClaudeBattery/ClaudeBattery/Views/IconRendering/DualArcGaugeRenderer.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/IconRendering/DualArcGaugeRenderer.swift
@@ -82,7 +82,7 @@ struct DualArcGaugeRenderer: IconRenderer {
 
     func makeBatteryIcon(usage: UsageData, color: NSColor) -> NSImage {
         let weeklyPercent = usage.weeklyRemaining
-        let sessionPercent = usage.sessionRemaining
+        let sessionPercent = usage.sessionDisplayRemaining
         let size = iconSize
         let baseColor = color
 

--- a/ClaudeBattery/ClaudeBattery/Views/IconRendering/DualHorizontalRenderer.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/IconRendering/DualHorizontalRenderer.swift
@@ -45,10 +45,14 @@ struct DualHorizontalRenderer: IconRenderer {
     }
 
     func makeBatteryIcon(usage: UsageData, color: NSColor) -> NSImage {
-        let weeklyPercent = Int(usage.weeklyRemaining)
-        let sessionPercent = Int(usage.sessionRemaining)
-        let isSessionLow = sessionPercent < 20
-        let isWeeklyLow = weeklyPercent < 20
+        // Round, don't truncate: the popover prints these numbers with "%.0f", so 15.6 must not
+        // draw "15" here and "16%" there. `.toNearestOrEven` because that is what "%.0f" does at
+        // exact halves - plain .rounded() goes half-away-from-zero and would draw 17 against the
+        // popover's 16. Low flags read the raw value, matching the popover's red.
+        let weeklyPercent = Int(usage.weeklyRemaining.rounded(.toNearestOrEven))
+        let sessionPercent = Int(usage.sessionDisplayRemaining.rounded(.toNearestOrEven))
+        let isSessionLow = usage.sessionDisplayRemaining < 20
+        let isWeeklyLow = usage.weeklyRemaining < 20
 
         let numberFont = NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .heavy)
         let smallNumberFont = NSFont.monospacedDigitSystemFont(ofSize: 8.5, weight: .heavy)

--- a/ClaudeBattery/ClaudeBattery/Views/IconRendering/MinimalRenderer.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/IconRendering/MinimalRenderer.swift
@@ -64,10 +64,10 @@ struct MinimalRenderer: IconRenderer {
     }
 
     func makeBatteryIcon(usage: UsageData, color: NSColor) -> NSImage {
-        let weeklyPercent = Int(usage.weeklyRemaining)
-        let sessionPercent = Int(usage.sessionRemaining)
-        let isSessionLow = sessionPercent < 20
-        let isWeeklyLow = weeklyPercent < 20
+        let weeklyPercent = Int(usage.weeklyRemaining.rounded(.toNearestOrEven))
+        let sessionPercent = Int(usage.sessionDisplayRemaining.rounded(.toNearestOrEven))
+        let isSessionLow = usage.sessionDisplayRemaining < 20
+        let isWeeklyLow = usage.weeklyRemaining < 20
 
         let fillInset: CGFloat = 1.5
         let dividerGap: CGFloat = 1.0

--- a/ClaudeBattery/ClaudeBattery/Views/IconRendering/StackedBarsRenderer.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/IconRendering/StackedBarsRenderer.swift
@@ -56,9 +56,9 @@ struct StackedBarsRenderer: IconRenderer {
     }
 
     func makeBatteryIcon(usage: UsageData, color: NSColor) -> NSImage {
-        makeBarsIcon(sessionFraction: CGFloat(usage.sessionRemaining) / 100.0,
+        makeBarsIcon(sessionFraction: CGFloat(usage.sessionDisplayRemaining) / 100.0,
                      weeklyFraction: CGFloat(usage.weeklyRemaining) / 100.0,
-                     sessionLow: usage.sessionRemaining < 20,
+                     sessionLow: usage.sessionDisplayRemaining < 20,
                      weeklyLow: usage.weeklyRemaining < 20,
                      color: color)
     }

--- a/ClaudeBattery/ClaudeBattery/Views/IconRendering/TextOnlyRenderer.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/IconRendering/TextOnlyRenderer.swift
@@ -49,8 +49,8 @@ struct TextOnlyRenderer: IconRenderer {
     }
 
     func makeBatteryIcon(usage: UsageData, color: NSColor) -> NSImage {
-        makeTextIcon(session: "\(Int(usage.sessionRemaining))",
-                     weekly: "\(Int(usage.weeklyRemaining))",
+        makeTextIcon(session: "\(Int(usage.sessionDisplayRemaining.rounded(.toNearestOrEven)))",
+                     weekly: "\(Int(usage.weeklyRemaining.rounded(.toNearestOrEven)))",
                      color: color)
     }
 }

--- a/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/MenuBarController.swift
@@ -384,6 +384,14 @@ class MenuBarController: NSObject {
     /// `compactCountdown` for the session reset when enabled and a positive countdown exists,
     /// else "" (the off/none state). `nonisolated static` so it is reachable from tests and
     /// free of controller state, mirroring `renderState`.
+    ///
+    /// The cell ALWAYS clocks the 5h session, including while the weekly limit binds. Accepted
+    /// consequence, decided deliberately: in that state the pill beside the cell shows
+    /// `sessionDisplayRemaining`, i.e. the weekly quota, so the clock reaches zero and the number
+    /// next to it does not move. Suppressing the cell there was tried and reverted - it removed
+    /// the reset time in the state where users most want it. The popover still hides the dial's
+    /// inner time arc for that same pairing (`suppressTimeArc:` in `UsagePopoverView.sessionCard`),
+    /// so the two surfaces differ here on purpose; do not "restore parity" without re-deciding this.
     nonisolated static func countdownTitle(usage: UsageData?, enabled: Bool, now: Date = Date()) -> String {
         guard enabled, let resetDate = usage?.sessionResetDate else { return "" }
         return CountdownFormat.compactCountdown(until: resetDate, now: now) ?? ""

--- a/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
+++ b/ClaudeBattery/ClaudeBattery/Views/UsagePopoverView.swift
@@ -123,11 +123,12 @@ struct UsagePopoverView: View {
     // the 3-bar model case the way a fixed height would.
 
     private func sessionCard(usage: UsageData) -> some View {
-        // The gauge shows the weekly-capped value (sessionGaugeRemaining) so a nearly-exhausted
-        // weekly can't display a high, unreachable session number; the pace is graded
+        // The gauge shows the weekly-capped value (sessionDisplayRemaining) so a nearly-exhausted
+        // weekly can't display a high, unreachable session number. The menu-bar renderers read the
+        // same value, so the two surfaces never disagree about "Session". The pace is graded
         // separately from the RAW session (via sessionPace) so the cap never corrupts it.
         gaugeCard(title: "Session",
-                  remaining: usage.sessionGaugeRemaining,
+                  remaining: usage.sessionDisplayRemaining,
                   resetsAt: usage.sessionResetDate,
                   window: Self.sessionWindow,
                   tickCount: 5,
@@ -336,7 +337,7 @@ struct UsagePopoverView: View {
     /// the Session defers to it (`.weeklyLimited`) - UNLESS the RAW 5h session is itself in Danger,
     /// a nearer concrete wall that must not be hidden behind "Limited by weekly". The pace always
     /// grades the RAW `sessionRemaining` over the 5h window, never the capped gauge value
-    /// (`sessionGaugeRemaining`), which is a weekly percentage over a weekly clock and would
+    /// (`sessionDisplayRemaining`), which is a weekly percentage over a weekly clock and would
     /// fabricate a bogus pace on the session timeline.
     static func sessionPace(for usage: UsageData, now: Date = Date()) -> PaceStatus {
         let raw = paceStatus(remainingPercent: usage.sessionRemaining,

--- a/ClaudeBattery/ClaudeBatteryTests/IconSignatureTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/IconSignatureTests.swift
@@ -276,18 +276,20 @@ final class IconSignatureTests: XCTestCase {
         XCTAssertNotEqual(sigA, sigB)
     }
 
-    // The popover Session gauge caps its value to a low weekly (sessionGaugeRemaining), but the
-    // menu bar must key on RAW sessionRemaining. Two snapshots with the same low weekly but
-    // different session collapse to the same capped gauge value, yet must produce DIFFERENT
-    // signatures - proving the weekly cap never folded into UsageData.sessionRemaining and broke
-    // the menu-bar renderers (which show session and weekly side by side).
-    func testMenuBarKeysOnRawSession_notWeeklyCappedGaugeValue() {
+    // The stored `sessionRemaining` must stay RAW. The weekly cap lives only in the derived
+    // `sessionDisplayRemaining`, never folded back into the field, because the #31 run-out
+    // forecast and the Session pace still grade the true 5h window. Two snapshots with the same
+    // low weekly but different raw session collapse to the same displayed value, yet must still
+    // produce DIFFERENT signatures: the signature carries the whole UsageData, so it stays a
+    // superset of what gets drawn - it may redraw an identical image, but never misses a changed
+    // one. See IconStyleTests for the drawn-value side of the contract.
+    func testWeeklyCapIsDerived_rawSessionSurvivesInTheSignature() {
         let high = RenderStateTests.makeUsage(sessionUtilization: 20, weeklyUtilization: 95) // session 80, weekly 5
         let low = RenderStateTests.makeUsage(sessionUtilization: 92, weeklyUtilization: 95)  // session 8, weekly 5
 
         XCTAssertTrue(high.isSessionWeeklyLimited)
         XCTAssertTrue(low.isSessionWeeklyLimited)
-        XCTAssertEqual(high.sessionGaugeRemaining, low.sessionGaugeRemaining, accuracy: 0.01) // both -> 5
+        XCTAssertEqual(high.sessionDisplayRemaining, low.sessionDisplayRemaining, accuracy: 0.01) // both -> 5
         XCTAssertNotEqual(high.sessionRemaining, low.sessionRemaining, accuracy: 0.01)        // 80 vs 8
 
         let sigHigh = makeSignature(isAuthenticated: true, usage: high)

--- a/ClaudeBattery/ClaudeBatteryTests/IconStyleTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/IconStyleTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AppKit
 @testable import ClaudeBattery
 
 final class IconStyleTests: XCTestCase {
@@ -61,6 +62,158 @@ final class IconStyleTests: XCTestCase {
         let actualRawValues = Set(IconStyle.allCases.map(\.rawValue))
         XCTAssertEqual(actualRawValues, expectedRawValues)
     }
+
+    // MARK: - Weekly cap: the menu bar shows what the popover shows
+
+    /// When the weekly limit binds, every menu-bar renderer must draw the same weekly-capped
+    /// session value the popover dial shows (`sessionDisplayRemaining`). Two snapshots sharing a
+    /// low weekly but differing wildly in raw session collapse to the same displayed value, so
+    /// their icons must come out identical. A renderer that slipped back to raw `sessionRemaining`
+    /// re-opens the reported mismatch: 51 in the menu bar next to 15 in the popover.
+    func testWeeklyLimited_allRenderersDrawTheCappedSession() {
+        let high = RenderStateTests.makeUsage(sessionUtilization: 20, weeklyUtilization: 95) // session 80, weekly 5
+        let low = RenderStateTests.makeUsage(sessionUtilization: 92, weeklyUtilization: 95)  // session 8,  weekly 5
+
+        XCTAssertTrue(high.isSessionWeeklyLimited)
+        XCTAssertTrue(low.isSessionWeeklyLimited)
+        XCTAssertNotEqual(high.sessionRemaining, low.sessionRemaining, accuracy: 0.01)
+        XCTAssertEqual(high.sessionDisplayRemaining, low.sessionDisplayRemaining, accuracy: 0.01)
+
+        for style in IconStyle.allCases {
+            let fromHighSession = style.renderer.makeBatteryIcon(usage: high, color: .white).tiffRepresentation
+            let fromLowSession = style.renderer.makeBatteryIcon(usage: low, color: .white).tiffRepresentation
+            XCTAssertNotNil(fromHighSession, "\(style.rawValue) produced no image data")
+            XCTAssertEqual(fromHighSession, fromLowSession,
+                           "\(style.rawValue) draws the raw session, not the weekly-capped value")
+        }
+    }
+
+    /// The cap is gated, not unconditional. In a healthy week the renderers keep showing the true
+    /// session, so two different sessions must still produce different icons.
+    ///
+    /// The `aboveWeekly` pair is what rules out an unconditional `min(session, weekly)`: both its
+    /// sessions sit ABOVE the same healthy weekly, so a renderer taking the minimum would draw 60
+    /// for both and the two icons would come out identical. The high/low pair alone cannot catch
+    /// that - min() leaves 8 alone, so those icons differ either way.
+    ///
+    /// Proving it by holding the session fixed and varying only the weekly is not an option: all
+    /// five styles draw the weekly into the same image, so a different weekly always changes the
+    /// bytes even when the session is drawn correctly.
+    func testHealthyWeekly_renderersStillShowTheRawSession() {
+        let high = RenderStateTests.makeUsage(sessionUtilization: 20, weeklyUtilization: 40) // session 80, weekly 60
+        let low = RenderStateTests.makeUsage(sessionUtilization: 92, weeklyUtilization: 40)  // session 8,  weekly 60
+        let aboveWeekly = RenderStateTests.makeUsage(sessionUtilization: 39, weeklyUtilization: 40) // session 61, weekly 60
+
+        XCTAssertFalse(high.isSessionWeeklyLimited)
+        XCTAssertFalse(low.isSessionWeeklyLimited)
+        XCTAssertFalse(aboveWeekly.isSessionWeeklyLimited)
+        // Same weekly, and both sessions clear it, so min() would flatten both onto that weekly.
+        XCTAssertEqual(high.weeklyRemaining, aboveWeekly.weeklyRemaining, accuracy: 0.01)
+        XCTAssertGreaterThan(high.sessionRemaining, high.weeklyRemaining)
+        XCTAssertGreaterThan(aboveWeekly.sessionRemaining, aboveWeekly.weeklyRemaining)
+
+        for style in IconStyle.allCases {
+            let fromHighSession = style.renderer.makeBatteryIcon(usage: high, color: .white).tiffRepresentation
+            let fromLowSession = style.renderer.makeBatteryIcon(usage: low, color: .white).tiffRepresentation
+            XCTAssertNotEqual(fromHighSession, fromLowSession,
+                              "\(style.rawValue) should still tell 80% and 8% apart in a healthy week")
+
+            let fromAboveWeekly = style.renderer.makeBatteryIcon(usage: aboveWeekly, color: .white).tiffRepresentation
+            XCTAssertNotNil(fromAboveWeekly, "\(style.rawValue) produced no image data")
+            XCTAssertNotEqual(fromHighSession, fromAboveWeekly,
+                              "\(style.rawValue) collapses 80% and 61% onto their shared 60% weekly, so it is capping unconditionally instead of only when the weekly is low")
+        }
+    }
+
+    // MARK: - Fractional percentages: the menu bar rounds the way the popover does
+
+    /// The popover prints its numbers with `%.0f`, which ROUNDS. The renderers that turn the
+    /// percentage into an `Int` must round too, or 15.6% remaining draws 15 in the menu bar while
+    /// the popover reads 16% - the same cross-surface mismatch this branch exists to close, one
+    /// digit smaller. So a fractional session must draw the icon its ROUNDED whole value draws,
+    /// and not the icon its TRUNCATED value draws.
+    ///
+    /// Only the `Int`-converting styles are checked. Stacked Bars and Dual Arc Gauge scale their
+    /// fills straight from the Double, so 15.6 legitimately draws slightly differently from both
+    /// 16 and 15 and there is no rounding choice to lock.
+    func testFractionalSession_renderersRoundRatherThanTruncate() {
+        // Weekly is healthy and identical across all three fixtures, so the cap gate stays off and
+        // the session value is the only thing moving.
+        let fractional = RenderStateTests.makeUsage(sessionUtilization: 84.4, weeklyUtilization: 40) // session 15.6
+        let rounded = RenderStateTests.makeUsage(sessionUtilization: 84, weeklyUtilization: 40)      // session 16
+        let truncated = RenderStateTests.makeUsage(sessionUtilization: 85, weeklyUtilization: 40)    // session 15
+
+        XCTAssertFalse(fractional.isSessionWeeklyLimited)
+        XCTAssertEqual(fractional.sessionDisplayRemaining, 15.6, accuracy: 0.001)
+        XCTAssertEqual(rounded.sessionDisplayRemaining, 16, accuracy: 0.001)
+        XCTAssertEqual(truncated.sessionDisplayRemaining, 15, accuracy: 0.001)
+
+        for style in Self.digitDrawingStyles {
+            let fromFraction = style.renderer.makeBatteryIcon(usage: fractional, color: .white).tiffRepresentation
+            let fromRounded = style.renderer.makeBatteryIcon(usage: rounded, color: .white).tiffRepresentation
+            let fromTruncated = style.renderer.makeBatteryIcon(usage: truncated, color: .white).tiffRepresentation
+            XCTAssertNotNil(fromFraction, "\(style.rawValue) produced no image data")
+            XCTAssertEqual(fromFraction, fromRounded,
+                           "\(style.rawValue) draws 15.6% as something other than 16, but the popover reads 16%")
+            XCTAssertNotEqual(fromFraction, fromTruncated,
+                              "\(style.rawValue) truncates 15.6% down to 15 while the popover reads 16%")
+        }
+    }
+
+    /// The weekly pill has to round the same way the session pill does. Without this, reverting the
+    /// weekly half of the rounding fix leaves the whole suite green, because every other fixture in
+    /// this file passes a whole-number weekly where truncating and rounding agree.
+    func testFractionalWeekly_renderersRoundItToo() {
+        // Session is healthy, whole, and well above the weekly, so the gate stays off and the
+        // weekly value is the only thing moving.
+        let fractional = RenderStateTests.makeUsage(sessionUtilization: 16, weeklyUtilization: 59.4) // weekly 40.6
+        let rounded = RenderStateTests.makeUsage(sessionUtilization: 16, weeklyUtilization: 59)      // weekly 41
+        let truncated = RenderStateTests.makeUsage(sessionUtilization: 16, weeklyUtilization: 60)    // weekly 40
+
+        XCTAssertFalse(fractional.isSessionWeeklyLimited)
+        XCTAssertEqual(fractional.weeklyRemaining, 40.6, accuracy: 0.001)
+
+        for style in Self.digitDrawingStyles {
+            let fromFraction = style.renderer.makeBatteryIcon(usage: fractional, color: .white).tiffRepresentation
+            let fromRounded = style.renderer.makeBatteryIcon(usage: rounded, color: .white).tiffRepresentation
+            let fromTruncated = style.renderer.makeBatteryIcon(usage: truncated, color: .white).tiffRepresentation
+            XCTAssertNotNil(fromFraction, "\(style.rawValue) produced no image data")
+            XCTAssertEqual(fromFraction, fromRounded,
+                           "\(style.rawValue) draws a weekly of 40.6% as something other than 41")
+            XCTAssertNotEqual(fromFraction, fromTruncated,
+                              "\(style.rawValue) truncates the weekly 40.6% down to 40")
+        }
+    }
+
+    /// An exact half is where the two surfaces are easiest to split apart: `%.0f` rounds half to
+    /// EVEN, so 16.5% prints as "16%" in the popover. A renderer using plain `.rounded()`
+    /// (half away from zero) would draw 17 beside it - the same cross-surface mismatch this branch
+    /// exists to close. Locks `.toNearestOrEven` specifically, not just "rounds somehow".
+    func testExactHalfSession_roundsHalfToEvenLikeThePopover() {
+        let half = RenderStateTests.makeUsage(sessionUtilization: 83.5, weeklyUtilization: 40)  // session 16.5
+        let even = RenderStateTests.makeUsage(sessionUtilization: 84, weeklyUtilization: 40)    // session 16
+        let awayFromZero = RenderStateTests.makeUsage(sessionUtilization: 83, weeklyUtilization: 40) // session 17
+
+        XCTAssertEqual(half.sessionDisplayRemaining, 16.5, accuracy: 0.001)
+        // The popover's own formatter is the contract this pins the renderers against.
+        XCTAssertEqual(String(format: "%.0f", half.sessionDisplayRemaining), "16")
+
+        for style in Self.digitDrawingStyles {
+            let fromHalf = style.renderer.makeBatteryIcon(usage: half, color: .white).tiffRepresentation
+            let fromEven = style.renderer.makeBatteryIcon(usage: even, color: .white).tiffRepresentation
+            let fromAway = style.renderer.makeBatteryIcon(usage: awayFromZero, color: .white).tiffRepresentation
+            XCTAssertEqual(fromHalf, fromEven,
+                           "\(style.rawValue) does not draw 16.5% as 16, but the popover's %.0f does")
+            XCTAssertNotEqual(fromHalf, fromAway,
+                              "\(style.rawValue) rounds 16.5% away from zero to 17 while the popover reads 16%")
+        }
+    }
+
+    /// Styles that turn the percentage into an `Int` and draw it as digits, so a rounding change
+    /// moves whole glyphs. Minimal is excluded on purpose: it converts to `Int` too, but its only
+    /// visible output is a fill height of `5.0 * percent / 100`, so one percentage point is a
+    /// 0.05pt difference decided by antialiasing - a flake risk, not a reliable assertion.
+    private static let digitDrawingStyles: [IconStyle] = [.textOnly, .dualHorizontal]
 
     // MARK: - Each renderer call returns a fresh instance (struct value type)
 

--- a/ClaudeBattery/ClaudeBatteryTests/MenuBarCountdownTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/MenuBarCountdownTests.swift
@@ -28,8 +28,59 @@ final class MenuBarCountdownTests: XCTestCase {
         decoder.dateDecodingStrategy = .iso8601
         let response = try decoder.decode(UsageResponse.self, from: Data(json.utf8))
         let usage = UsageData(from: response)
-        // Guard the fixture itself: the decode must yield the reset date the cases assume.
+        // Guard the fixture itself: the decode must yield the reset date the cases assume, and
+        // must NOT trip the weekly gate - with no weekly entry the decode falls back to the
+        // legacy tier and lands on 100 remaining, so the cases below see a plain countdown.
         XCTAssertEqual(usage.sessionResetDate, resetDate)
+        XCTAssertFalse(usage.isSessionWeeklyLimited)
+        return usage
+    }
+
+    /// Build a weekly-limited UsageData: session healthy (80 remaining) but weekly nearly gone
+    /// (5 remaining), so `sessionDisplayRemaining` - and therefore the session pill the countdown
+    /// cell sits beside - shows the WEEKLY number. `weekly_all` is the kind the production decode
+    /// reads for the weekly tier. Same `resets_at` as `makeUsage`, so a valid future session reset
+    /// exists and the weekly gate is the only thing that can explain an empty countdown.
+    private func makeWeeklyLimitedUsage() throws -> UsageData {
+        let json = """
+        {
+          "limits": [
+            { "kind": "session", "percent": 20, "resets_at": \(Int(resetEpoch)) },
+            { "kind": "weekly_all", "percent": 95, "resets_at": \(Int(resetEpoch)) }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        let response = try decoder.decode(UsageResponse.self, from: Data(json.utf8))
+        let usage = UsageData(from: response)
+        // Assert the fixture really is weekly-limited, so the case cannot silently rot into
+        // testing nothing if the gate's threshold or shape moves.
+        XCTAssertEqual(usage.sessionResetDate, resetDate)
+        XCTAssertTrue(usage.isSessionWeeklyLimited)
+        return usage
+    }
+
+    /// The same two-limit shape with a HEALTHY weekly (90 remaining), so the gate stays shut.
+    /// The control for `makeWeeklyLimitedUsage`: proves the suppression is gated on the weekly
+    /// limit binding rather than on merely having a weekly limit in the response.
+    private func makeWeeklyHealthyUsage() throws -> UsageData {
+        let json = """
+        {
+          "limits": [
+            { "kind": "session", "percent": 20, "resets_at": \(Int(resetEpoch)) },
+            { "kind": "weekly_all", "percent": 10, "resets_at": \(Int(resetEpoch)) }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        let response = try decoder.decode(UsageResponse.self, from: Data(json.utf8))
+        let usage = UsageData(from: response)
+        XCTAssertEqual(usage.sessionResetDate, resetDate)
+        XCTAssertFalse(usage.isSessionWeeklyLimited)
         return usage
     }
 
@@ -99,5 +150,36 @@ final class MenuBarCountdownTests: XCTestCase {
             usage: usage, enabled: true, now: now(secondsBeforeReset: -60)
         )
         XCTAssertEqual(title, "")
+    }
+
+    /// The countdown is deliberately NOT suppressed while the weekly limit binds. Suppressing it
+    /// was implemented and then reverted: it took the reset time away in the state where users
+    /// most want it. The known cost is locked here rather than left implicit - the pill beside
+    /// this cell shows the weekly quota, so this clock runs out without that number changing.
+    /// A future "consistency" change that empties the cell here has to overturn that decision.
+    func testEnabled_weeklyLimited_stillReturnsTheSessionCountdown() throws {
+        let usage = try makeWeeklyLimitedUsage()
+        let title = MenuBarController.countdownTitle(
+            usage: usage, enabled: true, now: now(secondsBeforeReset: 32 * 60)
+        )
+        XCTAssertEqual(title, "32m")
+    }
+
+    func testEnabled_weeklyHealthy_stillReturnsCountdown() throws {
+        let usage = try makeWeeklyHealthyUsage()
+        // The control: same two-limit shape with the gate shut. Together with the case above this
+        // pins that the cell is indifferent to the weekly gate, in both directions.
+        let title = MenuBarController.countdownTitle(
+            usage: usage, enabled: true, now: now(secondsBeforeReset: 32 * 60)
+        )
+        XCTAssertEqual(title, "32m")
+    }
+
+    func testDefaultFixture_withNoWeeklyLimit_isNotWeeklyLimited() throws {
+        let usage = try makeUsage()
+        // An absent weekly entry decodes to 100 remaining, which never binds. Keeps the two cases
+        // above honest: their difference really is the weekly gate and not the fixture shape.
+        XCTAssertEqual(usage.weeklyRemaining, 100)
+        XCTAssertFalse(usage.isSessionWeeklyLimited)
     }
 }

--- a/ClaudeBattery/ClaudeBatteryTests/RunOutForecastTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/RunOutForecastTests.swift
@@ -115,7 +115,7 @@ final class RunOutForecastTests: XCTestCase {
         // Discriminator: the capped gauge value (weekly=5) over the 5h window would grade Danger;
         // sessionPace must instead return .weeklyLimited (it grades the RAW session, which is ahead).
         let usage = makeUsage(session: 90, weekly: 5, sessionResetsIn: 9000)
-        let wrong = UsagePopoverView.paceStatus(remainingPercent: usage.sessionGaugeRemaining,
+        let wrong = UsagePopoverView.paceStatus(remainingPercent: usage.sessionDisplayRemaining,
                                                 resetsAt: usage.sessionResetDate, window: s, now: now)
         XCTAssertEqual(wrong, .danger)
         XCTAssertEqual(UsagePopoverView.sessionPace(for: usage, now: now), .weeklyLimited)

--- a/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
+++ b/ClaudeBattery/ClaudeBatteryTests/UsageServiceTests.swift
@@ -127,15 +127,15 @@ final class UsageDataTests: XCTestCase {
         // The reported bug: weekly nearly exhausted, session still high -> gauge must drop to weekly.
         let usage = makeUsage(session: 94, weekly: 2)
         XCTAssertTrue(usage.isSessionWeeklyLimited)
-        XCTAssertEqual(usage.sessionGaugeRemaining, 2, accuracy: 0.01)
-        // Raw session is untouched (menu bar + forecast keep the true 5h value).
+        XCTAssertEqual(usage.sessionDisplayRemaining, 2, accuracy: 0.01)
+        // Raw session is untouched (the #31 forecast and the pace keep the true 5h value).
         XCTAssertEqual(usage.sessionRemaining, 94, accuracy: 0.01)
     }
 
     func testGauge_weeklyExhausted_gaugeReadsZero() {
         let usage = makeUsage(session: 80, weekly: 0)
         XCTAssertTrue(usage.isSessionWeeklyLimited)
-        XCTAssertEqual(usage.sessionGaugeRemaining, 0, accuracy: 0.01)
+        XCTAssertEqual(usage.sessionDisplayRemaining, 0, accuracy: 0.01)
         XCTAssertEqual(usage.sessionRemaining, 80, accuracy: 0.01)
     }
 
@@ -145,7 +145,7 @@ final class UsageDataTests: XCTestCase {
         // min() would wrongly collapse the dial to 63% here.
         let usage = makeUsage(session: 94, weekly: 63)
         XCTAssertFalse(usage.isSessionWeeklyLimited)
-        XCTAssertEqual(usage.sessionGaugeRemaining, 94, accuracy: 0.01)
+        XCTAssertEqual(usage.sessionDisplayRemaining, 94, accuracy: 0.01)
     }
 
     func testGauge_sessionIsTighterLimit_showsSessionNotWeekly() {
@@ -153,7 +153,7 @@ final class UsageDataTests: XCTestCase {
         // limit, so the gauge shows the session and does NOT claim it is "weekly limited".
         let usage = makeUsage(session: 8, weekly: 15)
         XCTAssertFalse(usage.isSessionWeeklyLimited)
-        XCTAssertEqual(usage.sessionGaugeRemaining, 8, accuracy: 0.01)
+        XCTAssertEqual(usage.sessionDisplayRemaining, 8, accuracy: 0.01)
     }
 
     func testGauge_floorBoundary_isExclusiveAtTwenty() {
@@ -166,8 +166,8 @@ final class UsageDataTests: XCTestCase {
         // usage_limits_spend: session 94, weekly 63 -> healthy, gauge unchanged at 94.
         let usage = UsageData(from: try decodeFixture("usage_limits_spend"))
         XCTAssertFalse(usage.isSessionWeeklyLimited)
-        XCTAssertEqual(usage.sessionGaugeRemaining, usage.sessionRemaining, accuracy: 0.01)
-        XCTAssertEqual(usage.sessionGaugeRemaining, 94, accuracy: 0.01)
+        XCTAssertEqual(usage.sessionDisplayRemaining, usage.sessionRemaining, accuracy: 0.01)
+        XCTAssertEqual(usage.sessionDisplayRemaining, 94, accuracy: 0.01)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## The bug

When the weekly limit was nearly exhausted, the menu bar and the popover disagreed about a number they both label "Session": the menu bar read 51 while the popover read 15.

The weekly cap shipped in v1.60 for the popover dial only. All five menu-bar renderers still read the raw 5h value, so the two surfaces diverged whenever the gate fired (`weeklyRemaining < sessionRemaining && weeklyRemaining < 20`).

## The fix

Every renderer now reads the same derived value the popover uses, renamed `sessionGaugeRemaining` -> `sessionDisplayRemaining` since it is no longer popover-only. Raw `sessionRemaining` is untouched, so the #31 run-out forecast and the pace grading still work off the true 5h window.

Two things came out of review on top of that:

- **Rounding.** The three text renderers truncated where the popover rounds, so 15.6 would draw 15 next to a popover reading 16%. They now round half-to-even, which is what `%.0f` does. Plain `.rounded()` is not enough: it goes half away from zero and would draw 17 against the popover's 16 at exactly 16.5.
- **Test strength.** The icon tests could not fail if a renderer applied an unconditional `min(session, weekly)` instead of the gated value, because the fixtures happened to give the same pass/fail pattern either way. They now include a pair whose sessions both sit above a shared weekly, which collapses to one image under that regression.

## One deliberate inconsistency

The menu-bar countdown keeps clocking the 5h session even while the weekly binds, so the clock can run out without the number beside it moving.

Suppressing it there was implemented, reviewed, and then reverted after testing the build: it removed the reset time in exactly the state where it is wanted most. The popover still hides its dial's inner time arc for the same pairing, so the two surfaces differ here on purpose. That is recorded on `countdownTitle` and locked by a test, so a later "restore parity" change has to overturn a stated decision rather than assume an oversight.

## Verification

440 tests pass. Confirmed by hand in a signed build: the weekly-limited state now shows matching numbers on both surfaces with the countdown present.

Not included: no release, no DMG, no version bump.

Co-Authored-By: Katniss Everdeen (Claude Opus 5) <noreply@anthropic.com>
