### PR TITLE
chore(site): point the Windows beta download at 1.50.4-beta

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -555,7 +555,7 @@
            data-mac-href="https://github.com/Reebz/claude-battery/releases/download/v1.70/claude-battery_v1.70.dmg"
            data-mac-label="Download Mac"
            data-mac-version="(v1.70)"
-           data-win-href="https://github.com/Reebz/claude-battery/releases/download/windows-test-1.50.3-beta/ClaudeBattery-windows-test-1.50.3-beta-win-x64.zip"
+           data-win-href="https://github.com/Reebz/claude-battery/releases/download/windows-test-1.50.4-beta/ClaudeBattery-windows-test-1.50.4-beta-win-x64.zip"
            data-win-label="Download Win"
            data-win-version="(v1.50.3 beta)"
            class="btn btn-primary btn-download">
@@ -699,7 +699,7 @@
         <div class="install-card">
           <h3>Windows</h3>
           <p>Native Beta build. Unzip and run -- Windows may warn (unsigned).</p>
-          <a href="https://github.com/Reebz/claude-battery/releases/download/windows-test-1.50.3-beta/ClaudeBattery-windows-test-1.50.3-beta-win-x64.zip" class="btn btn-primary btn-download" style="width: 100%;">
+          <a href="https://github.com/Reebz/claude-battery/releases/download/windows-test-1.50.4-beta/ClaudeBattery-windows-test-1.50.4-beta-win-x64.zip" class="btn btn-primary btn-download" style="width: 100%;">
             <span class="btn-os-icon" aria-hidden="true">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-13.051-1.851"/></svg>
             </span>


### PR DESCRIPTION
Swaps the hero button and the Windows install card from windows-test-1.50.3-beta to windows-test-1.50.4-beta, the build with the review fix pass from PR #30. Merging deploys the site.

Co-Authored-By: Ronald Ulysses "Ron" Swanson (Claude Fable 5.1) <noreply@anthropic.com>